### PR TITLE
chore: only run release on tag creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:


### PR DESCRIPTION
Only executes the request workflow on tag creation.