### PR TITLE
bug: Corrected update-kubeconfig method to propagate target API server information to get-token command.

### DIFF
--- a/internal/datum/api_token_credentials.go
+++ b/internal/datum/api_token_credentials.go
@@ -25,7 +25,7 @@ type tokenResponse struct {
 func (s *apiTokenSource) Token() (*oauth2.Token, error) {
 	client := http.DefaultClient
 
-	url := fmt.Sprintf("https://%s/oauth/token/exchange", s.Hostname)
+	url := fmt.Sprintf("https://%s/datum-os/oauth/token/exchange", s.Hostname)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/resourcemanager/organizations.go
+++ b/internal/resourcemanager/organizations.go
@@ -42,7 +42,7 @@ func (r *OrganizationsAPI) ListOrganizations(ctx context.Context, req *resourcem
 	httpReq, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		fmt.Sprintf("https://%s/query", r.Hostname),
+		fmt.Sprintf("https://%s/datum-os/query", r.Hostname),
 		strings.NewReader(getAllOrganizationsRequest),
 	)
 	if err != nil {


### PR DESCRIPTION
Moved toward using the `/datum-os` path for interacting with Datum OS backed APIs, and adjusted the `update-kubeconfig` command to leverage a `hostname` flag instead of `base-url`. As mentioned in the summary, the `update-kubeconfig` command will now propagate the value of the `hostname` used during the command into the `get-token` command.