### PR TITLE
bugfix: fix table output

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -58,7 +58,7 @@ func printTable(w io.Writer, headers ColumnFormatter, rowData [][]any) error {
 	t := table.New(headers...)
 	t.WithWriter(w)
 	for _, row := range rowData {
-		t.AddRow(row)
+		t.AddRow(row...)
 	}
 	t.Print()
 	return nil


### PR DESCRIPTION
The table output was showing the organizations as an array of objects instead of outputting each column.

### Before

```shell
$ datumctl organizations list
DISPLAY NAME                                           RESOURCE ID
[Evolved Orca evolved-orca-irj30d]
[Personal Organization - Scot Wells personal-org-w2leui]
```

### After

```shell
$ go run . organizations list
DISPLAY NAME                        RESOURCE ID
Personal Organization - Scot Wells  personal-org-w2leui
```