### PR TITLE
mcp phase 2: add context switch and crud tools

### DIFF
--- a/internal/client/context_switch.go
+++ b/internal/client/context_switch.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/rest"
+
+	"go.datum.net/datumctl/internal/authutil"
+)
+
+func NewForProject(ctx context.Context, projectID, defaultNamespace string) (*K8sClient, error) {
+	cfg, err := restConfigFor(ctx, "", projectID)
+	if err != nil {
+		return nil, err
+	}
+	k, err := NewK8sFromRESTConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	k.Namespace = defaultNamespace
+	return k, nil
+}
+
+func NewForOrg(ctx context.Context, orgID, defaultNamespace string) (*K8sClient, error) {
+	cfg, err := restConfigFor(ctx, orgID, "")
+	if err != nil {
+		return nil, err
+	}
+	k, err := NewK8sFromRESTConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	k.Namespace = defaultNamespace
+	return k, nil
+}
+
+func restConfigFor(ctx context.Context, organizationID, projectID string) (*rest.Config, error) {
+	tknSrc, err := authutil.GetTokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get token source: %w", err)
+	}
+	apiHostname, err := authutil.GetAPIHostname()
+	if err != nil {
+		return nil, fmt.Errorf("get API hostname: %w", err)
+	}
+
+	var host string
+	switch {
+	case organizationID != "" && projectID == "":
+		host = fmt.Sprintf("https://%s/apis/resourcemanager.miloapis.com/v1alpha1/organizations/%s/control-plane",
+			apiHostname, organizationID)
+	case projectID != "" && organizationID == "":
+		host = fmt.Sprintf("https://%s/apis/resourcemanager.miloapis.com/v1alpha1/projects/%s/control-plane",
+			apiHostname, projectID)
+	default:
+		return nil, fmt.Errorf("exactly one of organizationID or projectID must be provided")
+	}
+
+	return &rest.Config{
+		Host: host,
+		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
+			return &oauth2.Transport{Source: tknSrc, Base: rt}
+		},
+	}, nil
+}

--- a/internal/client/k8s_client.go
+++ b/internal/client/k8s_client.go
@@ -3,12 +3,15 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -164,4 +167,303 @@ func splitYAMLDocuments(in []byte) [][]byte {
 		}
 	}
 	return out
+}
+
+type CreateOptions struct {
+	Kind         string
+	APIVersion   string // optional: "group/version" or "v1"
+	Name         string // set either Name or GenerateName
+	GenerateName string
+	Namespace    string
+	Labels       map[string]string
+	Annotations  map[string]string
+	Spec         map[string]any
+	DryRun       bool // default true at the tool layer
+}
+
+type GetOptions struct {
+	Kind       string
+	APIVersion string // optional
+	Name       string
+	Namespace  string
+}
+
+type ApplyOptions struct {
+	Kind        string
+	APIVersion  string // optional
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+	Spec        map[string]any
+	DryRun      bool
+	Force       bool // SSA: claim field ownership on conflicts
+}
+
+type DeleteOptions struct {
+	Kind       string
+	APIVersion string // optional
+	Name       string
+	Namespace  string
+	DryRun     bool
+}
+
+func (c *K8sClient) Create(ctx context.Context, opt CreateOptions) (*unstructured.Unstructured, error) {
+	rk, err := c.resolveKind(ctx, opt.Kind, opt.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+	obj := buildObject(buildObjectOpts{
+		APIVersion:   rk.GVK.GroupVersion().String(),
+		Kind:         rk.GVK.Kind,
+		Name:         opt.Name,
+		GenerateName: opt.GenerateName,
+		Namespace:    firstNonEmpty(opt.Namespace, c.Namespace),
+		Labels:       opt.Labels,
+		Annotations:  opt.Annotations,
+		Spec:         opt.Spec,
+	})
+
+	// keep namespaceable and resource interfaces separate
+	nsable := c.dyn.Resource(rk.GVR) // dynamic.NamespaceableResourceInterface
+	var ri dynamic.ResourceInterface
+	if rk.Namespaced {
+		ri = nsable.Namespace(obj.GetNamespace())
+	} else {
+		ri = nsable // Namespaceable implements ResourceInterface
+	}
+
+	return ri.Create(ctx, obj, metav1.CreateOptions{
+		DryRun: ternary(opt.DryRun, []string{metav1.DryRunAll}, nil),
+	})
+}
+
+func (c *K8sClient) Get(ctx context.Context, opt GetOptions) (*unstructured.Unstructured, error) {
+	rk, err := c.resolveKind(ctx, opt.Kind, opt.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	nsable := c.dyn.Resource(rk.GVR)
+	var ri dynamic.ResourceInterface
+	if rk.Namespaced {
+		ri = nsable.Namespace(firstNonEmpty(opt.Namespace, c.Namespace))
+	} else {
+		ri = nsable
+	}
+
+	return ri.Get(ctx, opt.Name, metav1.GetOptions{})
+}
+
+func (c *K8sClient) Apply(ctx context.Context, opt ApplyOptions) (*unstructured.Unstructured, error) {
+	rk, err := c.resolveKind(ctx, opt.Kind, opt.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+	obj := buildObject(buildObjectOpts{
+		APIVersion:  rk.GVK.GroupVersion().String(),
+		Kind:        rk.GVK.Kind,
+		Name:        opt.Name,
+		Namespace:   firstNonEmpty(opt.Namespace, c.Namespace),
+		Labels:      opt.Labels,
+		Annotations: opt.Annotations,
+		Spec:        opt.Spec,
+	})
+	jb, _ := json.Marshal(obj.Object)
+
+	nsable := c.dyn.Resource(rk.GVR)
+	var ri dynamic.ResourceInterface
+	if rk.Namespaced {
+		ri = nsable.Namespace(obj.GetNamespace())
+	} else {
+		ri = nsable
+	}
+
+	return ri.Patch(ctx, opt.Name, types.ApplyPatchType, jb, metav1.PatchOptions{
+		FieldManager: "datumctl-mcp",
+		Force:        &opt.Force,
+		DryRun:       ternary(opt.DryRun, []string{metav1.DryRunAll}, nil),
+	})
+}
+
+func (c *K8sClient) Delete(ctx context.Context, opt DeleteOptions) error {
+	rk, err := c.resolveKind(ctx, opt.Kind, opt.APIVersion)
+	if err != nil {
+		return err
+	}
+
+	nsable := c.dyn.Resource(rk.GVR)
+	var ri dynamic.ResourceInterface
+	if rk.Namespaced {
+		ri = nsable.Namespace(firstNonEmpty(opt.Namespace, c.Namespace))
+	} else {
+		ri = nsable
+	}
+
+	return ri.Delete(ctx, opt.Name, metav1.DeleteOptions{
+		DryRun: ternary(opt.DryRun, []string{metav1.DryRunAll}, nil),
+	})
+}
+
+// ListOptions lists instances of a Kind.
+type ListOptions struct {
+	Kind          string
+	APIVersion    string // optional
+	Namespace     string
+	LabelSelector string
+	FieldSelector string
+	Limit         int64
+	Continue      string
+}
+
+func (c *K8sClient) List(ctx context.Context, opt ListOptions) (*unstructured.UnstructuredList, error) {
+	rk, err := c.resolveKind(ctx, opt.Kind, opt.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+	nsable := c.dyn.Resource(rk.GVR)
+	var ri dynamic.ResourceInterface
+	if rk.Namespaced {
+		ri = nsable.Namespace(firstNonEmpty(opt.Namespace, c.Namespace))
+	} else {
+		ri = nsable
+	}
+	return ri.List(ctx, metav1.ListOptions{
+		LabelSelector: opt.LabelSelector,
+		FieldSelector: opt.FieldSelector,
+		Limit:         opt.Limit,
+		Continue:      opt.Continue,
+	})
+}
+
+// ToYAML returns a YAML string for a k8s object
+func ToYAML(u *unstructured.Unstructured) (string, error) {
+	jb, err := json.Marshal(u.Object)
+	if err != nil {
+		return "", err
+	}
+	yb, err := syaml.JSONToYAML(jb)
+	if err != nil {
+		return "", err
+	}
+	return string(yb), nil
+}
+
+// ToYAMLList renders a list to YAML (like `kubectl get -o yaml`).
+func ToYAMLList(l *unstructured.UnstructuredList) (string, error) {
+	jb, err := json.Marshal(l)
+	if err != nil {
+		return "", err
+	}
+	yb, err := syaml.JSONToYAML(jb)
+	if err != nil {
+		return "", err
+	}
+	return string(yb), nil
+}
+
+// ----- internal helpers (keep local to this file) -----
+
+type resolvedKind struct {
+	GVR        schema.GroupVersionResource
+	GVK        schema.GroupVersionKind
+	Namespaced bool
+}
+
+func (c *K8sClient) resolveKind(ctx context.Context, kind, apiVersion string) (*resolvedKind, error) {
+	gr, err := restmapper.GetAPIGroupResources(c.disco)
+	if err != nil {
+		return nil, fmt.Errorf("discovery: %w", err)
+	}
+	var candidates []resolvedKind
+	for _, grs := range gr {
+		group := grs.Group.Name
+		for ver, resources := range grs.VersionedResources {
+			for _, r := range resources {
+				if r.Kind != kind || strings.Contains(r.Name, "/") {
+					continue
+				}
+				gv := schema.GroupVersion{Group: group, Version: ver}
+				rk := resolvedKind{
+					GVR:        gv.WithResource(r.Name),
+					GVK:        gv.WithKind(kind),
+					Namespaced: r.Namespaced,
+				}
+				// include if no apiVersion filter, or matches explicit apiVersion ("group/version" or "v1")
+				if apiVersion == "" || gv.String() == apiVersion || (group == "" && ver == apiVersion) {
+					candidates = append(candidates, rk)
+				}
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, apierrs.NewNotFound(schema.GroupResource{Resource: strings.ToLower(kind)}, kind)
+	}
+	// If multiple apiVersions provide this Kind and none specified, ask the caller to disambiguate.
+	uniq := map[string]struct{}{}
+	for _, cnd := range candidates {
+		uniq[cnd.GVK.Group+"/"+cnd.GVK.Version] = struct{}{}
+	}
+	if apiVersion == "" && len(uniq) > 1 {
+		return nil, fmt.Errorf("kind %q is available in multiple apiVersions; please specify apiVersion", kind)
+	}
+	return &candidates[0], nil
+}
+
+type buildObjectOpts struct {
+	APIVersion   string
+	Kind         string
+	Name         string
+	GenerateName string
+	Namespace    string
+	Labels       map[string]string
+	Annotations  map[string]string
+	Spec         map[string]any
+}
+
+func buildObject(opts buildObjectOpts) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": opts.APIVersion,
+			"kind":       opts.Kind,
+			"metadata": map[string]any{
+				"labels":      map[string]string{},
+				"annotations": map[string]string{},
+			},
+			"spec": map[string]any{},
+		},
+	}
+	md := obj.Object["metadata"].(map[string]any)
+	if opts.Name != "" {
+		md["name"] = opts.Name
+	}
+	if opts.GenerateName != "" && opts.Name == "" {
+		md["generateName"] = opts.GenerateName
+	}
+	if opts.Namespace != "" {
+		md["namespace"] = opts.Namespace
+	}
+	if len(opts.Labels) > 0 {
+		md["labels"] = opts.Labels
+	}
+	if len(opts.Annotations) > 0 {
+		md["annotations"] = opts.Annotations
+	}
+	if opts.Spec != nil {
+		obj.Object["spec"] = opts.Spec
+	}
+	return obj
+}
+
+func ternary[T any](cond bool, a, b T) T {
+	if cond {
+		return a
+	}
+	return b
+}
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -27,8 +27,13 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Start the Datum MCP server",
-		Long: `Start a local MCP server that exposes tools to list CRDs, inspect CRDs,
-and validate manifests via server-side dry run. MCP clients (e.g., Claude) connect over STDIO.
+		Long: `Start a local MCP server exposing tools to:
+  • list & inspect CRDs
+  • validate manifests via server-side dry run
+  • generic CRUD (create/get/update/delete) for any served CRD
+  • switch context at runtime via datum/change_context
+
+MCP clients (e.g., Claude) connect over STDIO.
 Use --port to also expose a local HTTP debug API on 127.0.0.1:<port>.
 Select a Datum context with exactly one of --organization or --project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,7 +73,7 @@ Select a Datum context with exactly one of --organization or --project.`,
 	}
 
 	cmd.Flags().IntVar(&port, "port", 0, "Run HTTP debug API on 127.0.0.1:<port> (MCP still uses STDIO)")
-	cmd.Flags().StringVar(&namespace, "namespace", "", "Default namespace for validation (if YAML omits it)")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "Default namespace for CRUD/validation (if YAML or tool args omit it)")
 	cmd.Flags().StringVar(&organization, "organization", "", "Organization ID to target (mutually exclusive with --project)")
 	cmd.Flags().StringVar(&project, "project", "", "Project ID to target (mutually exclusive with --organization)")
 	return cmd

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -9,6 +9,8 @@ import (
 func ServeHTTP(s *Service, port int) error {
 	mux := http.NewServeMux()
 
+	// ----- Phase-1 debug endpoints -----
+
 	mux.HandleFunc("/datum/list_crds", func(w http.ResponseWriter, r *http.Request) {
 		if err := s.K.Preflight(r.Context()); err != nil {
 			jsonError(w, http.StatusUnauthorized, err)
@@ -50,8 +52,117 @@ func ServeHTTP(s *Service, port int) error {
 			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
 			return
 		}
-		// ValidateYAML returns a single value (the response struct)
 		res := s.ValidateYAML(r.Context(), req)
+		writeJSON(w, res)
+	})
+
+	// ----- debug endpoints (context + CRUD + list) -----
+
+	mux.HandleFunc("/datum/change_context", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req ChangeContextReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.ChangeContext(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, res)
+	})
+
+	mux.HandleFunc("/datum/create_resource", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req CreateResourceReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.CreateResource(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, res)
+	})
+
+	mux.HandleFunc("/datum/get_resource", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req GetResourceReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.GetResource(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, res)
+	})
+
+	mux.HandleFunc("/datum/update_resource", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req UpdateResourceReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.UpdateResource(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, res)
+	})
+
+	mux.HandleFunc("/datum/delete_resource", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req DeleteResourceReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.DeleteResource(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeJSON(w, res)
+	})
+
+	mux.HandleFunc("/datum/list_resources", func(w http.ResponseWriter, r *http.Request) {
+		if err := s.K.Preflight(r.Context()); err != nil {
+			jsonError(w, http.StatusUnauthorized, err)
+			return
+		}
+		var req ListResourcesReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid json: %w", err))
+			return
+		}
+		res, err := s.ListResources(r.Context(), req)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
 		writeJSON(w, res)
 	})
 

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -9,8 +9,6 @@ import (
 func ServeHTTP(s *Service, port int) error {
 	mux := http.NewServeMux()
 
-	// ----- Phase-1 debug endpoints -----
-
 	mux.HandleFunc("/datum/list_crds", func(w http.ResponseWriter, r *http.Request) {
 		if err := s.K.Preflight(r.Context()); err != nil {
 			jsonError(w, http.StatusUnauthorized, err)
@@ -55,8 +53,6 @@ func ServeHTTP(s *Service, port int) error {
 		res := s.ValidateYAML(r.Context(), req)
 		writeJSON(w, res)
 	})
-
-	// ----- debug endpoints (context + CRUD + list) -----
 
 	mux.HandleFunc("/datum/change_context", func(w http.ResponseWriter, r *http.Request) {
 		if err := s.K.Preflight(r.Context()); err != nil {

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -16,8 +16,6 @@ type Service struct {
 
 func NewService(k *client.K8sClient) *Service { return &Service{K: k} }
 
-// ---------- Phase-1 API types ----------
-
 type CRDItem struct {
 	Name     string   `json:"name"`
 	Group    string   `json:"group"`
@@ -44,8 +42,6 @@ type ValidateResp struct {
 	Valid  bool   `json:"valid"`
 	Output string `json:"output"`
 }
-
-// ---------- Phase-1 Methods ----------
 
 func (s *Service) ListCRDs(ctx context.Context) (ListCRDsResp, error) {
 	crds, err := s.K.ListCRDs(ctx) // native CRDs
@@ -115,8 +111,6 @@ func (s *Service) ValidateYAML(ctx context.Context, r ValidateReq) ValidateResp 
 	ok, out, _ := s.K.ValidateYAML(ctx, r.YAML)
 	return ValidateResp{Valid: ok, Output: out}
 }
-
-// ---------- New API types (CRUD + context + list) ----------
 
 type ChangeContextReq struct {
 	Project   string `json:"project,omitempty"`
@@ -190,8 +184,6 @@ type GetResourceResp struct {
 type ListResourcesResp struct {
 	Text string `json:"text"`
 }
-
-// ---------- New Methods (CRUD + context + list) ----------
 
 func (s *Service) ChangeContext(ctx context.Context, r ChangeContextReq) (ChangeContextResp, error) {
 	// namespace-only change
@@ -368,8 +360,7 @@ func (s *Service) ListResources(ctx context.Context, r ListResourcesReq) (ListRe
 	}
 }
 
-// ---------- small helper ----------
-
+// helper for getting the first non-empty string
 func firstNonEmpty(a, b string) string {
 	if a != "" {
 		return a

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -2,9 +2,9 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
-	"encoding/json"
 
 	"go.datum.net/datumctl/internal/client"
 	syaml "sigs.k8s.io/yaml"
@@ -16,7 +16,7 @@ type Service struct {
 
 func NewService(k *client.K8sClient) *Service { return &Service{K: k} }
 
-// ---------- API types ----------
+// ---------- Phase-1 API types ----------
 
 type CRDItem struct {
 	Name     string   `json:"name"`
@@ -45,7 +45,7 @@ type ValidateResp struct {
 	Output string `json:"output"`
 }
 
-// ---------- Methods ----------
+// ---------- Phase-1 Methods ----------
 
 func (s *Service) ListCRDs(ctx context.Context) (ListCRDsResp, error) {
 	crds, err := s.K.ListCRDs(ctx) // native CRDs
@@ -114,4 +114,265 @@ func (s *Service) GetCRD(ctx context.Context, r GetCRDReq) (GetCRDResp, error) {
 func (s *Service) ValidateYAML(ctx context.Context, r ValidateReq) ValidateResp {
 	ok, out, _ := s.K.ValidateYAML(ctx, r.YAML)
 	return ValidateResp{Valid: ok, Output: out}
+}
+
+// ---------- New API types (CRUD + context + list) ----------
+
+type ChangeContextReq struct {
+	Project   string `json:"project,omitempty"`
+	Org       string `json:"org,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+type ChangeContextResp struct {
+	OK        bool   `json:"ok"`
+	Project   string `json:"project,omitempty"`
+	Org       string `json:"org,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type CreateResourceReq struct {
+	Kind         string            `json:"kind"`
+	APIVersion   string            `json:"apiVersion,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	GenerateName string            `json:"generateName,omitempty"`
+	Namespace    string            `json:"namespace,omitempty"`
+	Spec         map[string]any    `json:"spec,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	DryRun       *bool             `json:"dryRun,omitempty"` // default true
+}
+type GetResourceReq struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+	Format     string `json:"format,omitempty"` // yaml (default) | json
+}
+type UpdateResourceReq struct {
+	Kind        string            `json:"kind"`
+	APIVersion  string            `json:"apiVersion,omitempty"`
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Spec        map[string]any    `json:"spec,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	DryRun      *bool             `json:"dryRun,omitempty"` // default true
+	Force       bool              `json:"force,omitempty"`  // SSA force
+}
+type DeleteResourceReq struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+	DryRun     *bool  `json:"dryRun,omitempty"` // default true
+}
+
+type ListResourcesReq struct {
+	Kind          string `json:"kind"`
+	APIVersion    string `json:"apiVersion,omitempty"`
+	Namespace     string `json:"namespace,omitempty"`
+	LabelSelector string `json:"labelSelector,omitempty"`
+	FieldSelector string `json:"fieldSelector,omitempty"`
+	Limit         *int64 `json:"limit,omitempty"`
+	Continue      string `json:"continue,omitempty"`
+	Format        string `json:"format,omitempty"` // "yaml" (default) | "names"
+}
+
+type OkResp struct {
+	OK              bool   `json:"ok"`
+	DryRun          bool   `json:"dryRun,omitempty"`
+	Validated       bool   `json:"validated,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+type GetResourceResp struct {
+	Text string `json:"text"`
+}
+type ListResourcesResp struct {
+	Text string `json:"text"`
+}
+
+// ---------- New Methods (CRUD + context + list) ----------
+
+func (s *Service) ChangeContext(ctx context.Context, r ChangeContextReq) (ChangeContextResp, error) {
+	// namespace-only change
+	if r.Project == "" && r.Org == "" && r.Namespace != "" {
+		s.K.Namespace = r.Namespace
+		return ChangeContextResp{OK: true, Namespace: s.K.Namespace}, nil
+	}
+	// require exactly one of project or org
+	if (r.Project == "") == (r.Org == "") {
+		return ChangeContextResp{}, fmt.Errorf("exactly one of project or org is required")
+	}
+
+	var (
+		next *client.K8sClient
+		err  error
+	)
+	if r.Project != "" {
+		next, err = client.NewForProject(ctx, r.Project, firstNonEmpty(r.Namespace, s.K.Namespace))
+	} else {
+		next, err = client.NewForOrg(ctx, r.Org, firstNonEmpty(r.Namespace, s.K.Namespace))
+	}
+	if err != nil {
+		return ChangeContextResp{}, err
+	}
+	if err := next.Preflight(ctx); err != nil {
+		return ChangeContextResp{}, err
+	}
+	s.K = next
+	return ChangeContextResp{OK: true, Project: r.Project, Org: r.Org, Namespace: s.K.Namespace}, nil
+}
+
+func (s *Service) CreateResource(ctx context.Context, r CreateResourceReq) (OkResp, error) {
+	if r.Kind == "" {
+		return OkResp{}, fmt.Errorf("kind is required")
+	}
+	dry := true
+	if r.DryRun != nil {
+		dry = *r.DryRun
+	}
+	obj, err := s.K.Create(ctx, client.CreateOptions{
+		Kind:         r.Kind,
+		APIVersion:   r.APIVersion,
+		Name:         r.Name,
+		GenerateName: r.GenerateName,
+		Namespace:    firstNonEmpty(r.Namespace, s.K.Namespace),
+		Labels:       r.Labels,
+		Annotations:  r.Annotations,
+		Spec:         r.Spec,
+		DryRun:       dry,
+	})
+	if err != nil {
+		return OkResp{}, err
+	}
+	if dry {
+		return OkResp{OK: true, DryRun: true, Validated: true}, nil
+	}
+	return OkResp{OK: true, ResourceVersion: obj.GetResourceVersion()}, nil
+}
+
+func (s *Service) GetResource(ctx context.Context, r GetResourceReq) (GetResourceResp, error) {
+	if r.Kind == "" || r.Name == "" {
+		return GetResourceResp{}, fmt.Errorf("kind and name are required")
+	}
+	obj, err := s.K.Get(ctx, client.GetOptions{
+		Kind:       r.Kind,
+		APIVersion: r.APIVersion,
+		Name:       r.Name,
+		Namespace:  firstNonEmpty(r.Namespace, s.K.Namespace),
+	})
+	if err != nil {
+		return GetResourceResp{}, err
+	}
+	if strings.ToLower(r.Format) == "json" {
+		jb, _ := json.MarshalIndent(obj.Object, "", "  ")
+		return GetResourceResp{Text: string(jb)}, nil
+	}
+	yb, err := client.ToYAML(obj)
+	if err != nil {
+		return GetResourceResp{}, err
+	}
+	return GetResourceResp{Text: yb}, nil
+}
+
+func (s *Service) UpdateResource(ctx context.Context, r UpdateResourceReq) (OkResp, error) {
+	if r.Kind == "" || r.Name == "" {
+		return OkResp{}, fmt.Errorf("kind and name are required")
+	}
+	dry := true
+	if r.DryRun != nil {
+		dry = *r.DryRun
+	}
+	obj, err := s.K.Apply(ctx, client.ApplyOptions{
+		Kind:        r.Kind,
+		APIVersion:  r.APIVersion,
+		Name:        r.Name,
+		Namespace:   firstNonEmpty(r.Namespace, s.K.Namespace),
+		Labels:      r.Labels,
+		Annotations: r.Annotations,
+		Spec:        r.Spec,
+		DryRun:      dry,
+		Force:       r.Force,
+	})
+	if err != nil {
+		return OkResp{}, err
+	}
+	if dry {
+		return OkResp{OK: true, DryRun: true, Validated: true}, nil
+	}
+	return OkResp{OK: true, ResourceVersion: obj.GetResourceVersion()}, nil
+}
+
+func (s *Service) DeleteResource(ctx context.Context, r DeleteResourceReq) (OkResp, error) {
+	if r.Kind == "" || r.Name == "" {
+		return OkResp{}, fmt.Errorf("kind and name are required")
+	}
+	dry := true
+	if r.DryRun != nil {
+		dry = *r.DryRun
+	}
+	if err := s.K.Delete(ctx, client.DeleteOptions{
+		Kind:       r.Kind,
+		APIVersion: r.APIVersion,
+		Name:       r.Name,
+		Namespace:  firstNonEmpty(r.Namespace, s.K.Namespace),
+		DryRun:     dry,
+	}); err != nil {
+		return OkResp{}, err
+	}
+	if dry {
+		return OkResp{OK: true, DryRun: true, Validated: true}, nil
+	}
+	return OkResp{OK: true}, nil
+}
+
+func (s *Service) ListResources(ctx context.Context, r ListResourcesReq) (ListResourcesResp, error) {
+	if r.Kind == "" {
+		return ListResourcesResp{}, fmt.Errorf("kind is required")
+	}
+	var lim int64
+	if r.Limit != nil {
+		lim = *r.Limit
+	}
+	lst, err := s.K.List(ctx, client.ListOptions{
+		Kind:          r.Kind,
+		APIVersion:    r.APIVersion,
+		Namespace:     firstNonEmpty(r.Namespace, s.K.Namespace),
+		LabelSelector: r.LabelSelector,
+		FieldSelector: r.FieldSelector,
+		Limit:         lim,
+		Continue:      r.Continue,
+	})
+	if err != nil {
+		return ListResourcesResp{}, err
+	}
+
+	switch strings.ToLower(r.Format) {
+	case "names":
+		var b strings.Builder
+		for i := range lst.Items {
+			n := lst.Items[i].GetName()
+			if ns := lst.Items[i].GetNamespace(); ns != "" {
+				fmt.Fprintf(&b, "%s/%s\n", ns, n)
+			} else {
+				fmt.Fprintln(&b, n)
+			}
+		}
+		return ListResourcesResp{Text: b.String()}, nil
+	default: // yaml
+		y, err := client.ToYAMLList(lst)
+		if err != nil {
+			return ListResourcesResp{}, err
+		}
+		return ListResourcesResp{Text: y}, nil
+	}
+}
+
+// ---------- small helper ----------
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -117,7 +117,6 @@ func (s *Service) RunSTDIO(port int) {
 			}
 
 			switch name {
-			// ------ Phase-1 tools ------
 			case "datum_list_crds":
 				res, err := s.ListCRDs(context.Background())
 				if err != nil {
@@ -147,7 +146,6 @@ func (s *Service) RunSTDIO(port int) {
 				res := s.ValidateYAML(context.Background(), r)
 				replyToolOK(req.ID, res)
 
-			// ------ New tools (CRUD + context + list) ------
 			case "datum_change_context":
 				var project, org, ns string
 				if args != nil {
@@ -515,7 +513,6 @@ func emit(resp jsonrpcResp) {
 
 func toolsList() []map[string]any {
 	return []map[string]any{
-		// phase-1
 		{
 			"name":        "datum_list_crds",
 			"description": "List CustomResourceDefinitions in the current cluster.",
@@ -544,7 +541,6 @@ func toolsList() []map[string]any {
 				"required": []any{"yaml"},
 			},
 		},
-		// new
 		{
 			"name":        "datum_change_context",
 			"description": "Switch project/org/namespace for this MCP session.",


### PR DESCRIPTION
This PR delivers the MCP Phase 2 implementation. The implementation includes context switching between organization and project scopes and full CRUD operations (create, get, update, delete, list) for any Datum resource.