### PR TITLE
chore: fix go test failure

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -186,7 +186,7 @@ func runLoginFlow(ctx context.Context, authHostname string, apiHostname string, 
 				}
 			}
 			http.Error(w, errMsg, http.StatusBadRequest)
-			errChan <- fmt.Errorf(errMsg)
+			errChan <- fmt.Errorf("%s", errMsg)
 			return
 		}
 


### PR DESCRIPTION
CI is failing because of a WARN in the codebase.

This PR fixes it
