### PR TITLE
chore(git): gitignore datumctl binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore goreleaser output
 dist/
+# Built binary
+/datumctl


### PR DESCRIPTION
The build leaves `datumctl` in the root directory. I assume we want git to ignore this.