### PR TITLE
fix: friendlier error for unauthenticated user

### DIFF
--- a/internal/authutil/credentials.go
+++ b/internal/authutil/credentials.go
@@ -24,7 +24,7 @@ const ActiveUserKey = "active_user"
 const KnownUsersKey = "known_users"
 
 // ErrNoActiveUser indicates that no active user is set in the keyring.
-var ErrNoActiveUser = errors.New("no active user set. Please login first")
+var ErrNoActiveUser = errors.New("You haven't authenticated with Datum Cloud yet. Please login first using 'datumctl auth login' and retry the command.")
 
 // StoredCredentials holds all necessary information for a single authenticated session.
 type StoredCredentials struct {

--- a/internal/cmd/auth/get_token.go
+++ b/internal/cmd/auth/get_token.go
@@ -51,7 +51,7 @@ func runGetToken(cmd *cobra.Command, args []string) error {
 	tokenSource, err := authutil.GetTokenSource(ctx)
 	if err != nil {
 		if errors.Is(err, authutil.ErrNoActiveUser) {
-			return errors.New("no active user found in keyring. Please login first using 'datumctl auth login'")
+			return err
 		}
 		return fmt.Errorf("failed to get token source: %w", err)
 	}


### PR DESCRIPTION
When a user is not logged, and never logged in the error message is not
that actionable. It says the user thy should login but now how to do it.

As reported by @ecv we can do a lot better.

There is another error that looks similar but exposes the right command
to run to login. This commit uses the same approach.

This is the current one in main
```
panic: failed to get token source: no active user set. Please login first

goroutine 1 [running]:
go.datum.net/datumctl/internal/cmd.RootCmd()
        /home/gianarb/git/datum/datumctl/internal/cmd/root.go:38 +0xc3a
main.main()
        /home/gianarb/git/datum/datumctl/main.go:15 +0x32
exit status 2
```

Here what user will get with this commit:

```
panic: failed to get token source: no active user set. Please login first using 'datumctl auth login'

goroutine 1 [running]:
go.datum.net/datumctl/internal/cmd.RootCmd()
        /home/gianarb/git/datum/datumctl/internal/cmd/root.go:38 +0xc3a
main.main()
        /home/gianarb/git/datum/datumctl/main.go:15 +0x32
exit status 2
```

NOTE: There is another race condition related to when we run
authentication and it prevents the `help` command to get printed to the
user. But I am working at it in another PR

Related https://github.com/datum-cloud/datumctl/issues/54
