### PR TITLE
fix: resource cmd with no args panics

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -6,6 +6,10 @@ import (
 
 func WrapResourceCommand(cmd *cobra.Command) *cobra.Command {
 	preRunFunc := func(cmd *cobra.Command, args []string) error {
+		// if there are not args we let the underline command to deal with it.
+		if len(args) == 0 {
+			return nil
+		}
 		// This mapping helps user during the getting started phase
 		if args[0] == "organizations" || args[0] == "organization" {
 			args[0] = "organizationmemberships"


### PR DESCRIPTION
The logic I wrote to remap some resources to something else
(organization membership to organization) for "resource commands" (like
get, delete, edit) does not cover the use case where the first argument
is omitted so it panics.

For example:

```
datumctl get

panic
```

With this fix it fallback to what the underline get command does (fails
with a nice error)
