### PR TITLE
fix: move authentication when factory is in use.

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,7 +25,6 @@ func RootCmd() *cobra.Command {
 		Use:   "datumctl",
 		Short: "A CLI for interacting with the Datum platform",
 	}
-
 	ioStreams := genericclioptions.IOStreams{
 		In:     rootCmd.InOrStdin(),
 		Out:    rootCmd.OutOrStdout(),
@@ -33,12 +32,7 @@ func RootCmd() *cobra.Command {
 	}
 
 	ctx := context.Background()
-	config, err := client.NewRestConfig(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	factory, err := client.NewDatumFactory(ctx, config)
+	factory, err := client.NewDatumFactory(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I think there is still something I need to learn about how factory are
supposed to work and the fact that I need to panic at some point if
something does not work since I can't gracefully return an error is a
sign of that but this commit fixes @ecv report about not being able to
run `--help` and `help` command because they requires authentication.

A valid concern!
