### PR TITLE
fix: force the account switcher

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -154,6 +154,7 @@ func runLoginFlow(ctx context.Context, authHostname string, apiHostname string, 
 	authURL := conf.AuthCodeURL(state,
 		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		oauth2.SetAuthURLParam("prompt", "select_account"),
 	)
 
 	// Channel to receive the authorization code


### PR DESCRIPTION
I was trying to `auth switch` with different account but my browser really, really wanted one of the accounts. This enables us to have the account chooser always appear, which is a fine compromise for a process that isn't very frequent.

FWIW, I think it was actually masking a separate issue with my user whose login had existed for a while and needed to be re-authed, so it was choosing the one that worked.

