### PR TITLE
fix: unbreak machine account login on macOS

### DIFF
--- a/internal/authutil/credentials.go
+++ b/internal/authutil/credentials.go
@@ -36,9 +36,14 @@ type MachineAccountState struct {
 	ClientEmail  string `json:"client_email"`
 	ClientID     string `json:"client_id"`
 	PrivateKeyID string `json:"private_key_id"`
-	PrivateKey   string `json:"private_key"`
+	PrivateKey   string `json:"private_key,omitempty"`
 	TokenURI     string `json:"token_uri"`
 	Scope        string `json:"scope,omitempty"`
+	// PrivateKeyPath is the path to an on-disk file containing the PEM-encoded
+	// private key. Used when the key is too large to store in the keyring (e.g.
+	// on macOS where the Keychain has a per-item size limit). If non-empty, the
+	// token source reads the key from this path instead of PrivateKey.
+	PrivateKeyPath string `json:"private_key_path,omitempty"`
 }
 
 // StoredCredentials holds all necessary information for a single authenticated session.

--- a/internal/authutil/machine_account_keyfile.go
+++ b/internal/authutil/machine_account_keyfile.go
@@ -3,6 +3,7 @@ package authutil
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,20 +44,54 @@ func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
 		return "", fmt.Errorf("failed to create machine account key directory %s: %w", dir, err)
 	}
 
+	// Tighten perms on the directory even when it already existed with looser ones.
+	if err := os.Chmod(dir, 0700); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("failed to set permissions on machine account key directory %s: %w", dir, err)
+	}
+
 	destPath, err := MachineAccountKeyFilePath(userKey)
 	if err != nil {
 		return "", err
 	}
 
-	tmpPath := destPath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(pemKey), 0600); err != nil {
-		return "", fmt.Errorf("failed to write machine account key to %s: %w", tmpPath, err)
+	// Use a unique temp filename so concurrent logins for the same account
+	// do not race on the same .tmp path and corrupt each other's writes.
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(destPath)+".tmp.*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file for machine account key in %s: %w", dir, err)
+	}
+	tmpName := tmpFile.Name()
+
+	// Ensure the temp file is removed on any error path. After a successful
+	// Rename the file no longer exists at tmpName, so Remove is a no-op.
+	var writeErr error
+	defer func() {
+		if writeErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	// Be explicit about mode even though CreateTemp already uses 0600.
+	if writeErr = tmpFile.Chmod(0600); writeErr != nil {
+		_ = tmpFile.Close()
+		writeErr = fmt.Errorf("failed to set permissions on temp key file %s: %w", tmpName, writeErr)
+		return "", writeErr
 	}
 
-	if err := os.Rename(tmpPath, destPath); err != nil {
-		// Best-effort cleanup of the temp file on rename failure.
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("failed to move machine account key to %s: %w", destPath, err)
+	if _, writeErr = tmpFile.Write([]byte(pemKey)); writeErr != nil {
+		_ = tmpFile.Close()
+		writeErr = fmt.Errorf("failed to write machine account key to %s: %w", tmpName, writeErr)
+		return "", writeErr
+	}
+
+	if writeErr = tmpFile.Close(); writeErr != nil {
+		writeErr = fmt.Errorf("failed to close temp key file %s: %w", tmpName, writeErr)
+		return "", writeErr
+	}
+
+	if writeErr = os.Rename(tmpName, destPath); writeErr != nil {
+		writeErr = fmt.Errorf("failed to move machine account key to %s: %w", destPath, writeErr)
+		return "", writeErr
 	}
 
 	return destPath, nil

--- a/internal/authutil/machine_account_keyfile.go
+++ b/internal/authutil/machine_account_keyfile.go
@@ -1,0 +1,85 @@
+package authutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// machineAccountKeyDir returns the directory used to store machine account PEM key files.
+// It does not create the directory.
+func machineAccountKeyDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user config directory: %w", err)
+	}
+	return filepath.Join(configDir, "datumctl", "machine-accounts"), nil
+}
+
+// MachineAccountKeyFilePath returns the on-disk path where the PEM key for
+// the given userKey is stored. It does not create the directory.
+func MachineAccountKeyFilePath(userKey string) (string, error) {
+	dir, err := machineAccountKeyDir()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(userKey))
+	filename := hex.EncodeToString(sum[:]) + ".pem"
+	return filepath.Join(dir, filename), nil
+}
+
+// WriteMachineAccountKeyFile atomically writes the PEM key to disk for the
+// given userKey and returns the absolute path. Creates the parent directory
+// with mode 0700 if needed. The file is written with mode 0600.
+func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
+	dir, err := machineAccountKeyDir()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create machine account key directory %s: %w", dir, err)
+	}
+
+	destPath, err := MachineAccountKeyFilePath(userKey)
+	if err != nil {
+		return "", err
+	}
+
+	tmpPath := destPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(pemKey), 0600); err != nil {
+		return "", fmt.Errorf("failed to write machine account key to %s: %w", tmpPath, err)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		// Best-effort cleanup of the temp file on rename failure.
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to move machine account key to %s: %w", destPath, err)
+	}
+
+	return destPath, nil
+}
+
+// ReadMachineAccountKeyFile reads a PEM key from the given path.
+func ReadMachineAccountKeyFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read machine account key file %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// RemoveMachineAccountKeyFile deletes the PEM key file for the given userKey.
+// Returns nil if the file does not exist.
+func RemoveMachineAccountKeyFile(userKey string) error {
+	path, err := MachineAccountKeyFilePath(userKey)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove machine account key file %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/authutil/machineaccount.go
+++ b/internal/authutil/machineaccount.go
@@ -203,11 +203,19 @@ func (m *machineAccountTokenSource) Token() (*oauth2.Token, error) {
 		var readErr error
 		pemKey, readErr = ReadMachineAccountKeyFile(ma.PrivateKeyPath)
 		if readErr != nil {
-			return nil, fmt.Errorf("failed to read machine account private key from %s: %w (try logging in again with 'datumctl auth login --credentials')", ma.PrivateKeyPath, readErr)
+			return nil, customerrors.WrapUserErrorWithHint(
+				"failed to read machine account private key from "+ma.PrivateKeyPath,
+				"re-run 'datumctl auth login --credentials <file>'; you may need to download a new machine account credentials file from the Datum portal if the original is no longer available",
+				readErr,
+			)
 		}
 	}
 	if pemKey == "" {
-		return nil, fmt.Errorf("machine account session is missing its private key; log in again with 'datumctl auth login --credentials'")
+		return nil, customerrors.WrapUserErrorWithHint(
+			"machine account session is missing its private key",
+			"re-run 'datumctl auth login --credentials <file>'; you may need to download a new machine account credentials file from the Datum portal if the original is no longer available",
+			nil,
+		)
 	}
 
 	signedJWT, err := MintJWT(ma.ClientID, ma.PrivateKeyID, pemKey, ma.TokenURI)

--- a/internal/authutil/machineaccount.go
+++ b/internal/authutil/machineaccount.go
@@ -194,7 +194,23 @@ func (m *machineAccountTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	ma := m.creds.MachineAccount
-	signedJWT, err := MintJWT(ma.ClientID, ma.PrivateKeyID, ma.PrivateKey, ma.TokenURI)
+
+	// Resolve the PEM key. New sessions store the key on disk (PrivateKeyPath)
+	// to stay within the macOS Keychain per-item size limit; older sessions
+	// (Linux, pre-fix) may still have the key inline in PrivateKey.
+	pemKey := ma.PrivateKey
+	if pemKey == "" && ma.PrivateKeyPath != "" {
+		var readErr error
+		pemKey, readErr = ReadMachineAccountKeyFile(ma.PrivateKeyPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read machine account private key from %s: %w (try logging in again with 'datumctl auth login --credentials')", ma.PrivateKeyPath, readErr)
+		}
+	}
+	if pemKey == "" {
+		return nil, fmt.Errorf("machine account session is missing its private key; log in again with 'datumctl auth login --credentials'")
+	}
+
+	signedJWT, err := MintJWT(ma.ClientID, ma.PrivateKeyID, pemKey, ma.TokenURI)
 	if err != nil {
 		return nil, customerrors.WrapUserErrorWithHint(
 			"Failed to mint JWT for machine account authentication.",

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -91,6 +91,11 @@ func logoutSingleUser(userKeyToLogout string) error {
 		if err := keyring.Delete(authutil.ServiceName, userKeyToLogout); err != nil && !errors.Is(err, keyring.ErrNotFound) {
 			fmt.Printf("Warning: attempt to delete potential stray key for %s failed: %v\n", userKeyToLogout, err)
 		}
+		// Also remove any stray on-disk PEM file. This is the exact cleanup path
+		// users hit after a failed login left crypto material behind (issue #146).
+		if removeErr := authutil.RemoveMachineAccountKeyFile(userKeyToLogout); removeErr != nil {
+			fmt.Printf("Warning: failed to remove machine account key file for '%s': %v\n", userKeyToLogout, removeErr)
+		}
 		return nil
 	}
 

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -100,6 +100,14 @@ func logoutSingleUser(userKeyToLogout string) error {
 		fmt.Printf("Warning: failed to delete credentials for user '%s' from keyring: %v\n", userKeyToLogout, err)
 	}
 
+	// Remove the on-disk PEM key file for machine account sessions.
+	// This is a best-effort cleanup: ignore "not found" (interactive sessions
+	// never write a file) and only warn on other errors since the keyring entry
+	// is already gone.
+	if removeErr := authutil.RemoveMachineAccountKeyFile(userKeyToLogout); removeErr != nil {
+		fmt.Printf("Warning: failed to remove machine account key file for '%s': %v\n", userKeyToLogout, removeErr)
+	}
+
 	// 4. Update and save the known users list
 	updatedJSON, err := json.Marshal(updatedKnownUsers)
 	if err != nil {
@@ -163,6 +171,11 @@ func logoutAllUsers() error {
 		if err != nil && !errors.Is(err, keyring.ErrNotFound) {
 			fmt.Printf("Warning: failed to delete credentials for user '%s' from keyring: %v\n", userKey, err)
 			logoutErrors = true // Mark that at least one error occurred
+		}
+
+		// Remove the on-disk PEM key file for machine account sessions (best-effort).
+		if removeErr := authutil.RemoveMachineAccountKeyFile(userKey); removeErr != nil {
+			fmt.Printf("Warning: failed to remove machine account key file for '%s': %v\n", userKey, removeErr)
 		}
 	}
 

--- a/internal/cmd/auth/machine_account_login.go
+++ b/internal/cmd/auth/machine_account_login.go
@@ -160,6 +160,11 @@ func runMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 	}
 
 	if err := keyring.Set(authutil.ServiceName, userKey, string(credsJSON)); err != nil {
+		// The PEM key was written to disk but the keyring write failed. Remove the
+		// key file as best-effort cleanup so we don't leave crypto material behind.
+		if cleanupErr := authutil.RemoveMachineAccountKeyFile(userKey); cleanupErr != nil {
+			fmt.Printf("Warning: failed to remove machine account key file after keyring error for %s: %v\n", userKey, cleanupErr)
+		}
 		return fmt.Errorf("failed to store credentials in keyring for %s: %w", userKey, err)
 	}
 

--- a/internal/cmd/auth/machine_account_login.go
+++ b/internal/cmd/auth/machine_account_login.go
@@ -115,6 +115,20 @@ func runMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 		displayName = creds.ClientID
 	}
 
+	// Use client_email as the keyring key when available; fall back to client_id.
+	userKey := creds.ClientEmail
+	if userKey == "" {
+		userKey = creds.ClientID
+	}
+
+	// Write the PEM private key to disk to keep the keyring blob small.
+	// On macOS the Keychain has a per-item size limit (~4 KB); embedding the
+	// PEM (~2.5 KB) alongside the access token pushes the blob over the limit.
+	keyFilePath, err := authutil.WriteMachineAccountKeyFile(userKey, creds.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to write machine account private key to disk: %w", err)
+	}
+
 	stored := authutil.StoredCredentials{
 		Hostname:         hostname,
 		APIHostname:      finalAPIHostname,
@@ -129,19 +143,15 @@ func runMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 			ClientEmail:  creds.ClientEmail,
 			ClientID:     creds.ClientID,
 			PrivateKeyID: creds.PrivateKeyID,
-			PrivateKey:   creds.PrivateKey,
+			// PrivateKey is intentionally left empty; the key lives on disk at
+			// PrivateKeyPath so the keyring blob stays under the macOS size limit.
+			PrivateKeyPath: keyFilePath,
 			// Store the discovered token URI and resolved scope so that the
 			// machineAccountTokenSource can refresh tokens without re-reading
 			// the credentials file.
 			TokenURI: tokenURI,
 			Scope:    scope,
 		},
-	}
-
-	// Use client_email as the keyring key when available; fall back to client_id.
-	userKey := creds.ClientEmail
-	if userKey == "" {
-		userKey = creds.ClientID
 	}
 
 	credsJSON, err := json.Marshal(stored)


### PR DESCRIPTION
## Summary

On macOS, logging in with a machine account credentials file authenticates successfully but then fails with `error: failed to store credentials in keyring ... data passed to Set was too big`, leaving no usable session behind. Machine account logins are effectively broken on macOS today.

The cause is a size limit on macOS Keychain items (~4 KB): the machine account session stored a full PEM-encoded RSA private key alongside the access token, pushing the blob over the limit. Interactive (browser) login doesn't hit this because it has no private key to store.

## What changed for users

- Machine account login now works on macOS.
- The private key is stored in a 0600 file under the user's config directory (`~/Library/Application Support/datumctl/machine-accounts/` on macOS, `~/.config/datumctl/machine-accounts/` on Linux, `%AppData%\datumctl\machine-accounts\` on Windows). The access token continues to live in the OS keyring/keychain.
- Logging out removes both the keyring entry and the on-disk key file.
- Existing sessions on Linux where the key still lived in the keyring keep working without any migration — the client reads from whichever location the key is in.

Fixes #146

## Test plan

- [ ] `datumctl auth login --credentials ./my-key.json` on macOS — completes without the keyring size error and leaves a working session
- [ ] Subsequent `datumctl` commands use the machine-account session (token refresh works after the initial token expires)
- [ ] `datumctl auth logout <machine-account>` removes the session and cleans up the on-disk key file
- [ ] Existing Linux sessions created with v0.13.1 continue to refresh without re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)