### PR TITLE
feat: add ai agent json format and context

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.datum.net/datumctl/internal/client"
@@ -12,6 +13,7 @@ import (
 	"go.datum.net/datumctl/internal/cmd/login"
 	"go.datum.net/datumctl/internal/cmd/logout"
 	"go.datum.net/datumctl/internal/cmd/whoami"
+	customerrors "go.datum.net/datumctl/internal/errors"
 	activity "go.miloapis.com/activity/pkg/cmd"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/apiresources"
@@ -59,9 +61,23 @@ Get started:
   datumctl get organizations
   datumctl get dnszones`,
 		Run: runLanding,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("error-format")
+			switch format {
+			case customerrors.FormatHuman, customerrors.FormatJSON, customerrors.FormatYAML:
+				return nil
+			default:
+				return customerrors.NewUserErrorWithHint(
+					fmt.Sprintf("invalid value %q for --error-format", format),
+					"Allowed values: human, json, yaml.",
+				)
+			}
+		},
 	}
 	// kubectl version expects this flag to exist; add it here to avoid nil deref.
 	rootCmd.PersistentFlags().Bool("warnings-as-errors", false, "Treat warnings as errors")
+	rootCmd.PersistentFlags().String("error-format", customerrors.FormatHuman,
+		"Error output format on failure. One of: human, json, yaml.")
 	ioStreams := genericclioptions.IOStreams{
 		In:     rootCmd.InOrStdin(),
 		Out:    rootCmd.OutOrStdout(),

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,8 +6,12 @@
 package errors
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
 )
 
 // UserError represents an error with a user-friendly message.
@@ -24,6 +28,14 @@ type UserError struct {
 
 	// Hint provides actionable guidance to help users resolve the issue.
 	Hint string
+
+	// Code is an optional machine-readable identifier (e.g., "AUTH_EXPIRED")
+	// for AI agents and other programmatic consumers to branch on.
+	Code string
+
+	// Retryable indicates whether the failed operation can be safely retried
+	// without further user action.
+	Retryable bool
 }
 
 // Error implements the error interface and returns the user-friendly message.
@@ -82,4 +94,81 @@ func WrapUserError(message string, err error) *UserError {
 // for debugging.
 func WrapUserErrorWithHint(message, hint string, err error) *UserError {
 	return &UserError{Message: message, Hint: hint, Err: err}
+}
+
+// Output formats supported by Format.
+const (
+	FormatHuman = "human"
+	FormatJSON  = "json"
+	FormatYAML  = "yaml"
+)
+
+// envelope is the structured payload emitted in json/yaml mode.
+type envelope struct {
+	Error envelopeError `json:"error"`
+}
+
+type envelopeError struct {
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message"`
+	Hint      string `json:"hint,omitempty"`
+	Retryable bool   `json:"retryable"`
+	Details   string `json:"details,omitempty"`
+}
+
+// Format writes err to w in the requested output format.
+//
+// For "human" (or any unknown value), output mirrors the legacy
+// "error: <message>\n<hint>" form, with the wrapped technical error appended
+// when verbosity is at least 4. For "json" and "yaml", a structured envelope
+// is emitted using the UserError fields when available, falling back to
+// err.Error() for non-UserError values.
+func Format(w io.Writer, err error, format string, verbosity int) {
+	if err == nil {
+		return
+	}
+
+	userErr, isUser := IsUserError(err)
+
+	switch format {
+	case FormatJSON, FormatYAML:
+		env := envelope{Error: envelopeError{Message: err.Error()}}
+		if isUser {
+			env.Error.Code = userErr.Code
+			env.Error.Message = userErr.Message
+			env.Error.Hint = userErr.Hint
+			env.Error.Retryable = userErr.Retryable
+			if userErr.Err != nil {
+				env.Error.Details = userErr.Err.Error()
+			}
+		}
+
+		var (
+			data []byte
+			marshalErr error
+		)
+		if format == FormatJSON {
+			data, marshalErr = json.Marshal(env)
+		} else {
+			data, marshalErr = yaml.Marshal(env)
+		}
+		if marshalErr != nil {
+			fmt.Fprintf(w, "error: %s\n", err.Error())
+			return
+		}
+		w.Write(data)
+		if format == FormatJSON {
+			fmt.Fprintln(w)
+		}
+
+	default:
+		if isUser {
+			fmt.Fprintf(w, "error: %s\n", userErr.Error())
+			if verbosity >= 4 && userErr.Err != nil {
+				fmt.Fprintf(w, "\nDetails:\n%v\n", userErr.Err)
+			}
+			return
+		}
+		fmt.Fprintf(w, "error: %s\n", err.Error())
+	}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,176 @@
+package errors
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestFormatHuman(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		verbosity int
+		want      string
+	}{
+		{
+			name: "user error with hint",
+			err:  NewUserErrorWithHint("session expired", "Run `datumctl auth login`."),
+			want: "error: session expired\nRun `datumctl auth login`.\n",
+		},
+		{
+			name: "user error without hint",
+			err:  NewUserError("not logged in"),
+			want: "error: not logged in\n",
+		},
+		{
+			name: "wrapped technical error, low verbosity hides details",
+			err:  WrapUserError("login failed", errors.New("oauth2: token expired")),
+			want: "error: login failed\n",
+		},
+		{
+			name:      "wrapped technical error, verbosity 4 shows details",
+			err:       WrapUserError("login failed", errors.New("oauth2: token expired")),
+			verbosity: 4,
+			want:      "error: login failed\n\nDetails:\noauth2: token expired\n",
+		},
+		{
+			name: "plain error",
+			err:  errors.New("some failure"),
+			want: "error: some failure\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			Format(&buf, tt.err, FormatHuman, tt.verbosity)
+			if got := buf.String(); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want envelope
+	}{
+		{
+			name: "user error with hint",
+			err:  NewUserErrorWithHint("session expired", "Run `datumctl auth login`."),
+			want: envelope{Error: envelopeError{
+				Message:   "session expired",
+				Hint:      "Run `datumctl auth login`.",
+				Retryable: false,
+			}},
+		},
+		{
+			name: "user error with code and retryable",
+			err: &UserError{
+				Message:   "rate limited",
+				Code:      "RATE_LIMITED",
+				Retryable: true,
+			},
+			want: envelope{Error: envelopeError{
+				Code:      "RATE_LIMITED",
+				Message:   "rate limited",
+				Retryable: true,
+			}},
+		},
+		{
+			name: "wrapped technical error includes details",
+			err:  WrapUserError("login failed", errors.New("oauth2: token expired")),
+			want: envelope{Error: envelopeError{
+				Message: "login failed",
+				Details: "oauth2: token expired",
+			}},
+		},
+		{
+			name: "plain error",
+			err:  errors.New("some failure"),
+			want: envelope{Error: envelopeError{Message: "some failure"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			Format(&buf, tt.err, FormatJSON, 0)
+			out := strings.TrimSpace(buf.String())
+			var got envelope
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+			}
+			if got != tt.want {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+			if !strings.HasSuffix(buf.String(), "\n") {
+				t.Errorf("JSON output should end with newline, got %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestFormatJSONOmitsEmptyOptionalFields(t *testing.T) {
+	var buf bytes.Buffer
+	Format(&buf, NewUserError("simple"), FormatJSON, 0)
+
+	out := buf.String()
+	for _, field := range []string{"\"code\"", "\"hint\"", "\"details\""} {
+		if strings.Contains(out, field) {
+			t.Errorf("expected %s to be omitted, got %s", field, out)
+		}
+	}
+	// retryable must always be present so consumers can branch on it.
+	if !strings.Contains(out, "\"retryable\"") {
+		t.Errorf("expected retryable to be present, got %s", out)
+	}
+}
+
+func TestFormatYAML(t *testing.T) {
+	var buf bytes.Buffer
+	in := &UserError{
+		Message:   "session expired",
+		Hint:      "Run `datumctl auth login`.",
+		Code:      "AUTH_EXPIRED",
+		Retryable: false,
+		Err:       errors.New("oauth2: token expired"),
+	}
+	Format(&buf, in, FormatYAML, 0)
+
+	var got envelope
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid YAML: %v\noutput: %s", err, buf.String())
+	}
+	want := envelope{Error: envelopeError{
+		Code:      "AUTH_EXPIRED",
+		Message:   "session expired",
+		Hint:      "Run `datumctl auth login`.",
+		Retryable: false,
+		Details:   "oauth2: token expired",
+	}}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestFormatUnknownFallsBackToHuman(t *testing.T) {
+	var buf bytes.Buffer
+	Format(&buf, NewUserError("boom"), "xml", 0)
+	if got, want := buf.String(), "error: boom\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatNilNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	Format(&buf, nil, FormatJSON, 0)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output for nil error, got %q", buf.String())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
+	"github.com/spf13/cobra"
 	"go.datum.net/datumctl/internal/cmd"
 	customerrors "go.datum.net/datumctl/internal/errors"
 	"k8s.io/component-base/cli"
@@ -15,24 +18,50 @@ import (
 
 func main() {
 	logs.GlogSetter(kubectlcmd.GetLogVerbosity(os.Args))
-	cmd := cmd.RootCmd()
-	if err := cli.RunNoErrOutput(cmd); err != nil {
-		// Check if this is a user-facing error
-		if userErr, ok := customerrors.IsUserError(err); ok {
-			// Print clean user-friendly error message
-			fmt.Fprintf(os.Stderr, "error: %s\n", userErr.Error())
+	rootCmd := cmd.RootCmd()
 
-			// Show technical details in verbose mode (v >= 4)
-			verbosityStr := kubectlcmd.GetLogVerbosity(os.Args)
-			verbosity, _ := strconv.Atoi(verbosityStr)
-			if verbosity >= 4 && userErr.Err != nil {
-				fmt.Fprintf(os.Stderr, "\nDetails:\n%v\n", userErr.Err)
-			}
-
-			os.Exit(1)
+	// Route kubectl's internal fatal errors (from util.CheckErr) through the
+	// same Format helper so --error-format applies uniformly. In human mode
+	// we print kubectl's preformatted string verbatim to match legacy output;
+	// in structured modes we strip the "error: " prefix kubectl may add and
+	// re-encode the message inside the JSON/YAML envelope.
+	util.BehaviorOnFatal(func(msg string, code int) {
+		msg = strings.TrimSuffix(msg, "\n")
+		format := formatFor(rootCmd)
+		if format == customerrors.FormatHuman {
+			fmt.Fprintln(os.Stderr, msg)
+			os.Exit(code)
 		}
+		clean := strings.TrimPrefix(msg, "error: ")
+		customerrors.Format(os.Stderr, errors.New(clean), format, verbosity())
+		os.Exit(code)
+	})
 
-		// Fall back to standard kubectl error handling for technical errors
-		util.CheckErr(err)
+	if err := cli.RunNoErrOutput(rootCmd); err != nil {
+		customerrors.Format(os.Stderr, err, formatFor(rootCmd), verbosity())
+		os.Exit(1)
 	}
+}
+
+// formatFor reads --error-format off the parsed root command, falling back to
+// human when the flag is absent or unrecognized (e.g. when an error fires
+// before flag parsing completes).
+func formatFor(rootCmd *cobra.Command) string {
+	f := rootCmd.PersistentFlags().Lookup("error-format")
+	if f == nil {
+		return customerrors.FormatHuman
+	}
+	switch f.Value.String() {
+	case customerrors.FormatJSON:
+		return customerrors.FormatJSON
+	case customerrors.FormatYAML:
+		return customerrors.FormatYAML
+	default:
+		return customerrors.FormatHuman
+	}
+}
+
+func verbosity() int {
+	v, _ := strconv.Atoi(kubectlcmd.GetLogVerbosity(os.Args))
+	return v
 }


### PR DESCRIPTION
Fixed #148

`--error-format` by default is human but it accepts json and yaml as ewll
