### PR TITLE
Fix Homebrew releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,14 @@ jobs:
           go-version: stable
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -37,4 +45,5 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.TAP_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
-          repositories: homebrew-tap
+          repositories: datumctl,homebrew-tap
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
@@ -45,5 +45,4 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -97,6 +97,7 @@ brews:
     owner: datum-cloud
     name: homebrew-tap
     branch: main
+    token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 
 krews:
 - commit_author:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -97,7 +97,6 @@ brews:
     owner: datum-cloud
     name: homebrew-tap
     branch: main
-    token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 
 krews:
 - commit_author:


### PR DESCRIPTION
## What happened
Releases were failing because our automation was pushing directly to the Homebrew tap, which requires changes to go through a pull request.

## What changed
- Switched to the **Datum Release Bot** GitHub App for everything — creating the release and pushing to the tap
- Single token scoped to both `datumctl` and `homebrew-tap`, passed as `GITHUB_TOKEN` to GoReleaser
- No separate tap token needed anywhere

## Before merging
Make sure the Datum Release Bot GitHub App is:
- [x] Created in the datum-cloud org
- [x] Installed on both `datumctl` and `homebrew-tap`
- [x] Added as a bypass actor in the tap's branch ruleset
- [x] `RELEASE_BOT_APP_ID` and `RELEASE_BOT_APP_PRIVATE_KEY` org secrets are accessible to this repo