### PR TITLE
refactor(auth): rename MachineAccount to ServiceAccount

### DIFF
--- a/internal/authutil/context.go
+++ b/internal/authutil/context.go
@@ -64,7 +64,7 @@ func GetUserKeyForSession(sessionName string) (string, error) {
 // subsequent commands "just work." Returns the new session, or an error if no
 // usable keyring credentials are present.
 //
-// Works for both interactive and machine-account credentials, since both
+// Works for both interactive and service-account credentials, since both
 // populate the same StoredCredentials fields that Session consumes.
 func bootstrapSessionFromKeyring(cfg *datumconfig.ConfigV1Beta1) (*datumconfig.Session, error) {
 	if cfg == nil {

--- a/internal/authutil/credentials.go
+++ b/internal/authutil/credentials.go
@@ -30,9 +30,9 @@ var ErrNoActiveUser = customerrors.NewUserErrorWithHint(
 	"Please login first using: `datumctl auth login`",
 )
 
-// MachineAccountState holds fields needed to re-mint a JWT when the access token expires.
-// Only populated when CredentialType == "machine_account".
-type MachineAccountState struct {
+// ServiceAccountState holds fields needed to re-mint a JWT when the access token expires.
+// Only populated when CredentialType == "service_account".
+type ServiceAccountState struct {
 	ClientEmail  string `json:"client_email"`
 	ClientID     string `json:"client_id"`
 	PrivateKeyID string `json:"private_key_id"`
@@ -60,9 +60,9 @@ type StoredCredentials struct {
 	Subject          string        `json:"subject"`            // User's Subject ID (sub claim from JWT)
 	// CredentialType distinguishes how stored credentials should be refreshed.
 	// "" or "interactive" → standard oauth2 refresh token path.
-	// "machine_account"  → re-mint JWT and re-exchange on expiry.
+	// "service_account"  → re-mint JWT and re-exchange on expiry.
 	CredentialType string               `json:"credential_type,omitempty"`
-	MachineAccount *MachineAccountState `json:"machine_account,omitempty"`
+	ServiceAccount *ServiceAccountState `json:"service_account,omitempty"`
 }
 
 // GetActiveCredentials retrieves the StoredCredentials for the currently active user.
@@ -186,11 +186,11 @@ func GetTokenSourceForUser(ctx context.Context, userKey string) (oauth2.TokenSou
 }
 
 func tokenSourceFor(ctx context.Context, userKey string, creds *StoredCredentials) (oauth2.TokenSource, error) {
-	if creds.CredentialType == "machine_account" {
-		if creds.MachineAccount == nil {
-			return nil, fmt.Errorf("machine account credentials are missing from stored session")
+	if creds.CredentialType == "service_account" || creds.CredentialType == "datum_service_account" {
+		if creds.ServiceAccount == nil {
+			return nil, fmt.Errorf("service account credentials are missing from stored session")
 		}
-		return &machineAccountTokenSource{
+		return &serviceAccountTokenSource{
 			ctx:     ctx,
 			creds:   creds,
 			userKey: userKey,

--- a/internal/authutil/service_account_keyfile.go
+++ b/internal/authutil/service_account_keyfile.go
@@ -9,20 +9,20 @@ import (
 	"path/filepath"
 )
 
-// machineAccountKeyDir returns the directory used to store machine account PEM key files.
+// serviceAccountKeyDir returns the directory used to store service account PEM key files.
 // It does not create the directory.
-func machineAccountKeyDir() (string, error) {
+func serviceAccountKeyDir() (string, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to determine user config directory: %w", err)
 	}
-	return filepath.Join(configDir, "datumctl", "machine-accounts"), nil
+	return filepath.Join(configDir, "datumctl", "service-accounts"), nil
 }
 
-// MachineAccountKeyFilePath returns the on-disk path where the PEM key for
+// ServiceAccountKeyFilePath returns the on-disk path where the PEM key for
 // the given userKey is stored. It does not create the directory.
-func MachineAccountKeyFilePath(userKey string) (string, error) {
-	dir, err := machineAccountKeyDir()
+func ServiceAccountKeyFilePath(userKey string) (string, error) {
+	dir, err := serviceAccountKeyDir()
 	if err != nil {
 		return "", err
 	}
@@ -31,25 +31,25 @@ func MachineAccountKeyFilePath(userKey string) (string, error) {
 	return filepath.Join(dir, filename), nil
 }
 
-// WriteMachineAccountKeyFile atomically writes the PEM key to disk for the
+// WriteServiceAccountKeyFile atomically writes the PEM key to disk for the
 // given userKey and returns the absolute path. Creates the parent directory
 // with mode 0700 if needed. The file is written with mode 0600.
-func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
-	dir, err := machineAccountKeyDir()
+func WriteServiceAccountKeyFile(userKey, pemKey string) (string, error) {
+	dir, err := serviceAccountKeyDir()
 	if err != nil {
 		return "", err
 	}
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		return "", fmt.Errorf("failed to create machine account key directory %s: %w", dir, err)
+		return "", fmt.Errorf("failed to create service account key directory %s: %w", dir, err)
 	}
 
 	// Tighten perms on the directory even when it already existed with looser ones.
 	if err := os.Chmod(dir, 0700); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("failed to set permissions on machine account key directory %s: %w", dir, err)
+		return "", fmt.Errorf("failed to set permissions on service account key directory %s: %w", dir, err)
 	}
 
-	destPath, err := MachineAccountKeyFilePath(userKey)
+	destPath, err := ServiceAccountKeyFilePath(userKey)
 	if err != nil {
 		return "", err
 	}
@@ -58,7 +58,7 @@ func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
 	// do not race on the same .tmp path and corrupt each other's writes.
 	tmpFile, err := os.CreateTemp(dir, filepath.Base(destPath)+".tmp.*")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp file for machine account key in %s: %w", dir, err)
+		return "", fmt.Errorf("failed to create temp file for service account key in %s: %w", dir, err)
 	}
 	tmpName := tmpFile.Name()
 
@@ -80,7 +80,7 @@ func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
 
 	if _, writeErr = tmpFile.Write([]byte(pemKey)); writeErr != nil {
 		_ = tmpFile.Close()
-		writeErr = fmt.Errorf("failed to write machine account key to %s: %w", tmpName, writeErr)
+		writeErr = fmt.Errorf("failed to write service account key to %s: %w", tmpName, writeErr)
 		return "", writeErr
 	}
 
@@ -90,31 +90,31 @@ func WriteMachineAccountKeyFile(userKey, pemKey string) (string, error) {
 	}
 
 	if writeErr = os.Rename(tmpName, destPath); writeErr != nil {
-		writeErr = fmt.Errorf("failed to move machine account key to %s: %w", destPath, writeErr)
+		writeErr = fmt.Errorf("failed to move service account key to %s: %w", destPath, writeErr)
 		return "", writeErr
 	}
 
 	return destPath, nil
 }
 
-// ReadMachineAccountKeyFile reads a PEM key from the given path.
-func ReadMachineAccountKeyFile(path string) (string, error) {
+// ReadServiceAccountKeyFile reads a PEM key from the given path.
+func ReadServiceAccountKeyFile(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read machine account key file %s: %w", path, err)
+		return "", fmt.Errorf("failed to read service account key file %s: %w", path, err)
 	}
 	return string(data), nil
 }
 
-// RemoveMachineAccountKeyFile deletes the PEM key file for the given userKey.
+// RemoveServiceAccountKeyFile deletes the PEM key file for the given userKey.
 // Returns nil if the file does not exist.
-func RemoveMachineAccountKeyFile(userKey string) error {
-	path, err := MachineAccountKeyFilePath(userKey)
+func RemoveServiceAccountKeyFile(userKey string) error {
+	path, err := ServiceAccountKeyFilePath(userKey)
 	if err != nil {
 		return err
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove machine account key file %s: %w", path, err)
+		return fmt.Errorf("failed to remove service account key file %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/authutil/service_account_login.go
+++ b/internal/authutil/service_account_login.go
@@ -13,25 +13,25 @@ import (
 	"go.datum.net/datumctl/internal/keyring"
 )
 
-const defaultMachineAccountScope = "openid profile email offline_access"
+const defaultServiceAccountScope = "openid profile email offline_access"
 
-// RunMachineAccountLogin reads a machine account credentials file, discovers
+// RunServiceAccountLogin reads a service account credentials file, discovers
 // the token endpoint via OIDC, mints a JWT, exchanges it for an access token,
 // and stores the resulting session in the keyring. Returns a LoginResult so the
 // caller can build a v1beta1 Session.
-func RunMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiHostname string, debug bool) (*LoginResult, error) {
+func RunServiceAccountLogin(ctx context.Context, credentialsPath, hostname, apiHostname string, debug bool) (*LoginResult, error) {
 	data, err := os.ReadFile(credentialsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read credentials file %q: %w", credentialsPath, err)
 	}
 
-	var creds MachineAccountCredentials
+	var creds ServiceAccountCredentials
 	if err := json.Unmarshal(data, &creds); err != nil {
 		return nil, fmt.Errorf("failed to parse credentials file %q: %w", credentialsPath, err)
 	}
 
-	if creds.Type != "datum_machine_account" {
-		return nil, fmt.Errorf("unsupported credentials type %q: expected \"datum_machine_account\"", creds.Type)
+	if creds.Type != "datum_service_account" {
+		return nil, fmt.Errorf("unsupported credentials type %q: expected \"datum_service_account\"", creds.Type)
 	}
 
 	var missing []string
@@ -57,7 +57,7 @@ func RunMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 
 	scope := creds.Scope
 	if scope == "" {
-		scope = defaultMachineAccountScope
+		scope = defaultServiceAccountScope
 	}
 
 	finalAPIHostname := apiHostname
@@ -100,9 +100,9 @@ func RunMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 		userKey = creds.ClientID
 	}
 
-	keyFilePath, err := WriteMachineAccountKeyFile(userKey, creds.PrivateKey)
+	keyFilePath, err := WriteServiceAccountKeyFile(userKey, creds.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write machine account private key to disk: %w", err)
+		return nil, fmt.Errorf("failed to write service account private key to disk: %w", err)
 	}
 
 	stored := StoredCredentials{
@@ -114,8 +114,8 @@ func RunMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 		UserName:         displayName,
 		UserEmail:        creds.ClientEmail,
 		Subject:          creds.ClientID,
-		CredentialType:   "machine_account",
-		MachineAccount: &MachineAccountState{
+		CredentialType:   "service_account",
+		ServiceAccount: &ServiceAccountState{
 			ClientEmail:    creds.ClientEmail,
 			ClientID:       creds.ClientID,
 			PrivateKeyID:   creds.PrivateKeyID,
@@ -131,8 +131,8 @@ func RunMachineAccountLogin(ctx context.Context, credentialsPath, hostname, apiH
 	}
 
 	if err := keyring.Set(ServiceName, userKey, string(credsJSON)); err != nil {
-		if cleanupErr := RemoveMachineAccountKeyFile(userKey); cleanupErr != nil {
-			fmt.Printf("Warning: failed to remove machine account key file after keyring error for %s: %v\n", userKey, cleanupErr)
+		if cleanupErr := RemoveServiceAccountKeyFile(userKey); cleanupErr != nil {
+			fmt.Printf("Warning: failed to remove service account key file after keyring error for %s: %v\n", userKey, cleanupErr)
 		}
 		return nil, fmt.Errorf("failed to store credentials in keyring for %s: %w", userKey, err)
 	}

--- a/internal/authutil/serviceaccount.go
+++ b/internal/authutil/serviceaccount.go
@@ -24,9 +24,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// MachineAccountCredentials is the on-disk JSON format downloaded from the Datum Cloud portal.
-type MachineAccountCredentials struct {
-	Type         string `json:"type"`           // "datum_machine_account"
+// ServiceAccountCredentials is the on-disk JSON format downloaded from the Datum Cloud portal.
+type ServiceAccountCredentials struct {
+	Type         string `json:"type"`           // "datum_service_account"
 	APIEndpoint  string `json:"api_endpoint"`   // "https://api.datum.net"
 	TokenURI     string `json:"token_uri"`      // "https://auth.datum.net/oauth/v2/token"
 	Scope        string `json:"scope"`          // OAuth2 scope string, e.g. "openid profile email urn:zitadel:..."
@@ -172,10 +172,10 @@ func ExchangeJWT(ctx context.Context, tokenURI, signedJWT, scope string) (*oauth
 	return token, nil
 }
 
-// machineAccountTokenSource implements oauth2.TokenSource for machine account sessions.
+// serviceAccountTokenSource implements oauth2.TokenSource for service account sessions.
 // It re-mints a JWT and re-exchanges it whenever the stored access token has expired,
-// since machine account sessions have no refresh token.
-type machineAccountTokenSource struct {
+// since service account sessions have no refresh token.
+type serviceAccountTokenSource struct {
 	ctx     context.Context
 	creds   *StoredCredentials
 	userKey string
@@ -185,7 +185,7 @@ type machineAccountTokenSource struct {
 // Token implements oauth2.TokenSource. If the cached token is still valid it is
 // returned immediately. Otherwise a new JWT is minted, exchanged for an access
 // token, and the updated credentials are persisted to the keyring.
-func (m *machineAccountTokenSource) Token() (*oauth2.Token, error) {
+func (m *serviceAccountTokenSource) Token() (*oauth2.Token, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -193,41 +193,41 @@ func (m *machineAccountTokenSource) Token() (*oauth2.Token, error) {
 		return m.creds.Token, nil
 	}
 
-	ma := m.creds.MachineAccount
+	sa := m.creds.ServiceAccount
 
 	// Resolve the PEM key. New sessions store the key on disk (PrivateKeyPath)
 	// to stay within the macOS Keychain per-item size limit; older sessions
 	// (Linux, pre-fix) may still have the key inline in PrivateKey.
-	pemKey := ma.PrivateKey
-	if pemKey == "" && ma.PrivateKeyPath != "" {
+	pemKey := sa.PrivateKey
+	if pemKey == "" && sa.PrivateKeyPath != "" {
 		var readErr error
-		pemKey, readErr = ReadMachineAccountKeyFile(ma.PrivateKeyPath)
+		pemKey, readErr = ReadServiceAccountKeyFile(sa.PrivateKeyPath)
 		if readErr != nil {
 			return nil, customerrors.WrapUserErrorWithHint(
-				"failed to read machine account private key from "+ma.PrivateKeyPath,
-				"re-run 'datumctl auth login --credentials <file>'; you may need to download a new machine account credentials file from the Datum portal if the original is no longer available",
+				"failed to read service account private key from "+sa.PrivateKeyPath,
+				"re-run 'datumctl auth login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
 				readErr,
 			)
 		}
 	}
 	if pemKey == "" {
 		return nil, customerrors.WrapUserErrorWithHint(
-			"machine account session is missing its private key",
-			"re-run 'datumctl auth login --credentials <file>'; you may need to download a new machine account credentials file from the Datum portal if the original is no longer available",
+			"service account session is missing its private key",
+			"re-run 'datumctl auth login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
 			nil,
 		)
 	}
 
-	signedJWT, err := MintJWT(ma.ClientID, ma.PrivateKeyID, pemKey, ma.TokenURI)
+	signedJWT, err := MintJWT(sa.ClientID, sa.PrivateKeyID, pemKey, sa.TokenURI)
 	if err != nil {
 		return nil, customerrors.WrapUserErrorWithHint(
-			"Failed to mint JWT for machine account authentication.",
+			"Failed to mint JWT for service account authentication.",
 			"Please re-authenticate using: `datumctl auth login --credentials <file>`",
 			err,
 		)
 	}
 
-	token, err := ExchangeJWT(m.ctx, ma.TokenURI, signedJWT, ma.Scope)
+	token, err := ExchangeJWT(m.ctx, sa.TokenURI, signedJWT, sa.Scope)
 	if err != nil {
 		return nil, customerrors.WrapUserErrorWithHint(
 			"Failed to exchange JWT for access token.",
@@ -241,11 +241,11 @@ func (m *machineAccountTokenSource) Token() (*oauth2.Token, error) {
 	credsJSON, err := json.Marshal(m.creds)
 	if err != nil {
 		// Return token even if persistence fails — the caller can still proceed.
-		return token, fmt.Errorf("failed to marshal updated machine account credentials: %w", err)
+		return token, fmt.Errorf("failed to marshal updated service account credentials: %w", err)
 	}
 
 	if err := keyring.Set(ServiceName, m.userKey, string(credsJSON)); err != nil {
-		return token, fmt.Errorf("failed to persist refreshed machine account token to keyring: %w", err)
+		return token, fmt.Errorf("failed to persist refreshed service account token to keyring: %w", err)
 	}
 
 	return token, nil

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -36,7 +36,7 @@ By default, opens your browser for OAuth2 PKCE authentication. Use
 --no-browser in headless environments (SSH, CI, containers) to authenticate
 via a device-code flow that does not need a browser on this machine.
 
-Use --credentials to authenticate as a machine account (non-interactive).`,
+Use --credentials to authenticate as a service account (non-interactive).`,
 		Example: `  # Log in (opens browser, then picks a context)
   datumctl login
 
@@ -46,7 +46,7 @@ Use --credentials to authenticate as a machine account (non-interactive).`,
   # Log in to a staging environment
   datumctl login --hostname auth.staging.env.datum.net
 
-  # Log in with a machine account credentials file
+  # Log in with a service account credentials file
   datumctl login --credentials ./my-key.json --hostname auth.staging.env.datum.net`,
 		RunE: runLogin,
 	}
@@ -55,7 +55,7 @@ Use --credentials to authenticate as a machine account (non-interactive).`,
 	cmd.Flags().StringVar(&apiHostnameFlag, "api-hostname", "", "Hostname of the Datum Cloud API server (derived from auth hostname if omitted)")
 	cmd.Flags().StringVar(&clientIDFlag, "client-id", "", "Override the OAuth2 Client ID")
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Use the device authorization flow instead of opening a browser")
-	cmd.Flags().StringVar(&credentialsFile, "credentials", "", "Path to a machine account credentials JSON file")
+	cmd.Flags().StringVar(&credentialsFile, "credentials", "", "Path to a service account credentials JSON file")
 	cmd.Flags().BoolVar(&debugCredentials, "debug", false, "Print JWT claims and token request details (credentials flow only)")
 
 	return cmd
@@ -68,7 +68,7 @@ func runLogin(cmd *cobra.Command, _ []string) error {
 	var authHostname string
 
 	if credentialsFile != "" {
-		r, err := authutil.RunMachineAccountLogin(ctx, credentialsFile, hostname, apiHostnameFlag, debugCredentials)
+		r, err := authutil.RunServiceAccountLogin(ctx, credentialsFile, hostname, apiHostnameFlag, debugCredentials)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,7 +100,7 @@ Get started:
 	// Top-level auth entry points. Promoted out of the 'auth' subgroup so that
 	// new users find 'datumctl login' at the root of the CLI, while experienced
 	// users can still reach 'datumctl auth login' for advanced options
-	// (machine-account, device flow).
+	// (service-account, device flow).
 	loginCmd := login.Command()
 	loginCmd.GroupID = "auth"
 	rootCmd.AddCommand(loginCmd)


### PR DESCRIPTION
## Summary

- Renames `MachineAccountCredentials` → `ServiceAccountCredentials`, `MachineAccountState` → `ServiceAccountState`
- Updates credential type strings: `datum_machine_account` → `datum_service_account`, `machine_account` → `service_account`
- Changes key file directory: `~/.config/datumctl/machine-accounts/` → `service-accounts/`
- File renames: `machineaccount.go` → `serviceaccount.go`, `machine_account_keyfile.go` → `service_account_keyfile.go`, `machine_account_login.go` → `service_account_login.go`

Companion to datum-cloud/milo#<milo-pr> — pre-GA breaking rename aligning with industry-standard service account terminology.

## Test plan

- [x] `grep -r "MachineAccount\|machineAccount\|machine_account\|machine-account" --include="*.go" | grep -v _test.go` returns zero results
- [x] `go build ./...` passes
- [ ] `datumctl auth login --credentials <service-account-key-file>` works end-to-end