### PR TITLE
fix: update nix flake to Go 1.26

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
       in
       {
         packages = {
-          default = pkgs.buildGoModule {
+          default = (pkgs.buildGoModule.override { go = pkgs.go_1_26; }) {
             pname = "datumctl";
             inherit version;
 
@@ -61,7 +61,7 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            go_1_25
+            go_1_26
             gopls
             gotools
             go-task


### PR DESCRIPTION
## Summary

- Updates `buildGoModule` to use `go_1_26` (was `go_1_25`)
- Updates `devShells` to use `go_1_26`

`golang.org/x/term v0.42.0` (and transitive deps) now requires Go >= 1.25.8, but the nix flake was pinned to `go_1_25` which resolved to 1.25.5 in CI. This caused the `update-hash` nix CI job to fail with `go: go.mod requires go >= 1.25.8 (running go 1.25.5; GOTOOLCHAIN=local)` — before it could even produce the hash mismatch output needed to update `vendorHash`.

The `go.mod` already declares `toolchain go1.26.2`, so this aligns nix with the stated toolchain.

Merging this unblocks PR #175 (Renovate `golang.org/x/term` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)