### PR TITLE
fix: remove transparent boxes from context switcher

### DIFF
--- a/internal/console/components/ctxswitcher.go
+++ b/internal/console/components/ctxswitcher.go
@@ -139,16 +139,16 @@ func nextSelectable(entries []treeEntry, cur, dir int) int {
 }
 
 func (m CtxSwitcherModel) View() string {
-	headerStyle := lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
-	selectedStyle := lipgloss.NewStyle().Foreground(styles.Accent).Bold(true)
-	normalStyle := lipgloss.NewStyle().Foreground(styles.Secondary)
-	currentStyle := lipgloss.NewStyle().Foreground(styles.Success)
-	muted := lipgloss.NewStyle().Foreground(styles.Muted).Italic(true)
+	headerStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Primary).Bold(true)
+	selectedStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
+	normalStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
+	currentStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success)
+	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted).Italic(true)
 
 	var lines []string
 
 	if m.cfg == nil || len(m.cfg.Contexts) == 0 {
-		empty := lipgloss.NewStyle().Foreground(styles.Muted).
+		empty := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted).
 			Width(ctxModalWidth - 4).Align(lipgloss.Center).
 			Render("No contexts available")
 		lines = append(lines, empty)
@@ -179,6 +179,7 @@ func (m CtxSwitcherModel) View() string {
 	lines = append(lines, "", footer)
 
 	body := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	body = styles.SurfaceFill(body, ctxModalWidth, lipgloss.Height(body))
 	modal := styles.OverlayStyle.Width(ctxModalWidth).Render(body)
 
 	return lipgloss.Place(m.width, m.height,


### PR DESCRIPTION
## Summary

- The context switcher overlay was showing light-colored boxes behind some entries when opened
- Entries now render with a solid dark background, consistent with the rest of the console UI

## Test plan

- [ ] Open `datumctl console`, press the context-switch keybind, and confirm no transparent/white boxes appear behind any entry in the overlay
- [ ] Confirm the selected entry, current context marker, and org headers all render cleanly on the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)