### PR TITLE
Log in to Datum Cloud without leaving the console

### DIFF
--- a/internal/authutil/credentials.go
+++ b/internal/authutil/credentials.go
@@ -30,6 +30,11 @@ var ErrNoActiveUser = customerrors.NewUserErrorWithHint(
 	"Please login first using: `datumctl auth login`",
 )
 
+// IsNoActiveUser reports whether err wraps ErrNoActiveUser.
+func IsNoActiveUser(err error) bool {
+	return errors.Is(err, ErrNoActiveUser)
+}
+
 // ServiceAccountState holds fields needed to re-mint a JWT when the access token expires.
 // Only populated when CredentialType == "service_account".
 type ServiceAccountState struct {

--- a/internal/authutil/login.go
+++ b/internal/authutil/login.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -110,7 +111,7 @@ func RunInteractiveLogin(ctx context.Context, authHostname, apiHostname, clientI
 		}
 	}
 
-	return completeLogin(ctx, provider, clientID, authHostname, finalAPIHostname, scopes, token, verbose, false)
+	return completeLogin(ctx, provider, clientID, authHostname, finalAPIHostname, scopes, token, verbose, os.Stdout)
 }
 
 // runPKCEFlow executes the OAuth2 PKCE authorization code flow and returns the
@@ -239,7 +240,7 @@ func runPKCEFlow(ctx context.Context, provider *oidc.Provider, clientID string, 
 // completeLogin verifies the ID token, stores credentials in the keyring, sets
 // the active user, registers the user in the known-users list, and returns a
 // LoginResult.
-func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authHostname, finalAPIHostname string, scopes []string, token *oauth2.Token, verbose, quiet bool) (*LoginResult, error) {
+func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authHostname, finalAPIHostname string, scopes []string, token *oauth2.Token, verbose bool, out io.Writer) (*LoginResult, error) {
 	idTokenString, ok := token.Extra("id_token").(string)
 	if !ok {
 		return nil, fmt.Errorf("id_token not found in token response")
@@ -267,9 +268,7 @@ func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authH
 		return nil, fmt.Errorf("could not extract email claim from ID token, which is required for user identification")
 	}
 
-	if !quiet {
-		fmt.Printf("\nAuthenticated as: %s (%s)\n", claims.Name, claims.Email)
-	}
+	fmt.Fprintf(out, "\nAuthenticated as: %s (%s)\n", claims.Name, claims.Email)
 
 	// Use email as the keyring key for interactive logins, matching the
 	// behaviour of the original cmd/auth/login.go implementation.
@@ -299,26 +298,20 @@ func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authH
 
 	activeUserSet := false
 	if err := keyring.Set(ServiceName, ActiveUserKey, userKey); err != nil {
-		if !quiet {
-			fmt.Printf("Warning: Failed to set '%s' as active user in keyring: %v\n", userKey, err)
-			fmt.Printf("Credentials for '%s' were stored successfully.\n", userKey)
-		}
+		fmt.Fprintf(out, "Warning: Failed to set '%s' as active user in keyring: %v\n", userKey, err)
+		fmt.Fprintf(out, "Credentials for '%s' were stored successfully.\n", userKey)
 	} else {
 		activeUserSet = true
 	}
 
-	if !quiet {
-		if activeUserSet {
-			fmt.Println("Authentication successful. Credentials stored and set as active.")
-		} else {
-			fmt.Println("Authentication successful. Credentials stored.")
-		}
+	if activeUserSet {
+		fmt.Fprintln(out, "Authentication successful. Credentials stored and set as active.")
+	} else {
+		fmt.Fprintln(out, "Authentication successful. Credentials stored.")
 	}
 
 	if err := AddKnownUserKey(userKey); err != nil {
-		if !quiet {
-			fmt.Printf("Warning: Failed to update list of known users: %v\n", err)
-		}
+		fmt.Fprintf(out, "Warning: Failed to update list of known users: %v\n", err)
 	}
 
 	if verbose {
@@ -420,7 +413,7 @@ func StartDeviceAuth(ctx context.Context, authHostname, apiHostname, clientID st
 
 // FinishDeviceAuth polls for the device token and completes the login by storing
 // credentials in the keyring. It returns the LoginResult on success.
-func FinishDeviceAuth(ctx context.Context, session *DeviceAuthSession, quiet bool) (*LoginResult, error) {
+func FinishDeviceAuth(ctx context.Context, session *DeviceAuthSession, out io.Writer) (*LoginResult, error) {
 	token, err := pollDeviceToken(ctx, session.TokenURL, session.ClientID, session.DeviceCode, session.Interval, session.ExpiresIn)
 	if err != nil {
 		return nil, err
@@ -433,7 +426,7 @@ func FinishDeviceAuth(ctx context.Context, session *DeviceAuthSession, quiet boo
 	}
 
 	scopes := []string{oidc.ScopeOpenID, "profile", "email", oidc.ScopeOfflineAccess}
-	return completeLogin(ctx, provider, session.ClientID, session.AuthHostname, session.APIHostname, scopes, token, false, quiet)
+	return completeLogin(ctx, provider, session.ClientID, session.AuthHostname, session.APIHostname, scopes, token, false, out)
 }
 
 type deviceTokenResponse struct {

--- a/internal/authutil/login.go
+++ b/internal/authutil/login.go
@@ -110,7 +110,7 @@ func RunInteractiveLogin(ctx context.Context, authHostname, apiHostname, clientI
 		}
 	}
 
-	return completeLogin(ctx, provider, clientID, authHostname, finalAPIHostname, scopes, token, verbose)
+	return completeLogin(ctx, provider, clientID, authHostname, finalAPIHostname, scopes, token, verbose, false)
 }
 
 // runPKCEFlow executes the OAuth2 PKCE authorization code flow and returns the
@@ -239,7 +239,7 @@ func runPKCEFlow(ctx context.Context, provider *oidc.Provider, clientID string, 
 // completeLogin verifies the ID token, stores credentials in the keyring, sets
 // the active user, registers the user in the known-users list, and returns a
 // LoginResult.
-func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authHostname, finalAPIHostname string, scopes []string, token *oauth2.Token, verbose bool) (*LoginResult, error) {
+func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authHostname, finalAPIHostname string, scopes []string, token *oauth2.Token, verbose, quiet bool) (*LoginResult, error) {
 	idTokenString, ok := token.Extra("id_token").(string)
 	if !ok {
 		return nil, fmt.Errorf("id_token not found in token response")
@@ -267,7 +267,9 @@ func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authH
 		return nil, fmt.Errorf("could not extract email claim from ID token, which is required for user identification")
 	}
 
-	fmt.Printf("\nAuthenticated as: %s (%s)\n", claims.Name, claims.Email)
+	if !quiet {
+		fmt.Printf("\nAuthenticated as: %s (%s)\n", claims.Name, claims.Email)
+	}
 
 	// Use email as the keyring key for interactive logins, matching the
 	// behaviour of the original cmd/auth/login.go implementation.
@@ -297,20 +299,26 @@ func completeLogin(ctx context.Context, provider *oidc.Provider, clientID, authH
 
 	activeUserSet := false
 	if err := keyring.Set(ServiceName, ActiveUserKey, userKey); err != nil {
-		fmt.Printf("Warning: Failed to set '%s' as active user in keyring: %v\n", userKey, err)
-		fmt.Printf("Credentials for '%s' were stored successfully.\n", userKey)
+		if !quiet {
+			fmt.Printf("Warning: Failed to set '%s' as active user in keyring: %v\n", userKey, err)
+			fmt.Printf("Credentials for '%s' were stored successfully.\n", userKey)
+		}
 	} else {
 		activeUserSet = true
 	}
 
-	if activeUserSet {
-		fmt.Println("Authentication successful. Credentials stored and set as active.")
-	} else {
-		fmt.Println("Authentication successful. Credentials stored.")
+	if !quiet {
+		if activeUserSet {
+			fmt.Println("Authentication successful. Credentials stored and set as active.")
+		} else {
+			fmt.Println("Authentication successful. Credentials stored.")
+		}
 	}
 
 	if err := AddKnownUserKey(userKey); err != nil {
-		fmt.Printf("Warning: Failed to update list of known users: %v\n", err)
+		if !quiet {
+			fmt.Printf("Warning: Failed to update list of known users: %v\n", err)
+		}
 	}
 
 	if verbose {
@@ -347,6 +355,85 @@ type deviceAuthorizationResponse struct {
 	VerificationURIComplete string `json:"verification_uri_complete"`
 	ExpiresIn               int64  `json:"expires_in"`
 	Interval                int64  `json:"interval"`
+}
+
+// DeviceAuthSession holds the state of an initiated device authorization flow.
+// Callers use this to display the verification URL/code and to poll for completion.
+type DeviceAuthSession struct {
+	VerificationURI string
+	UserCode        string
+	DeviceCode      string
+	TokenURL        string
+	ClientID        string
+	AuthHostname    string
+	APIHostname     string
+	Interval        int64
+	ExpiresIn       int64
+}
+
+// StartDeviceAuth initiates a device authorization request against the given
+// auth hostname and returns a session the caller can display to the user while
+// polling for completion.
+func StartDeviceAuth(ctx context.Context, authHostname, apiHostname, clientID string) (*DeviceAuthSession, error) {
+	if apiHostname == "" {
+		derived, err := DeriveAPIHostname(authHostname)
+		if err != nil {
+			return nil, err
+		}
+		apiHostname = derived
+	}
+
+	providerURL := fmt.Sprintf("https://%s", authHostname)
+	_, err := oidc.NewProvider(ctx, providerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover OIDC provider at %s: %w", providerURL, err)
+	}
+
+	scopes := []string{oidc.ScopeOpenID, "profile", "email", oidc.ScopeOfflineAccess}
+
+	base := strings.TrimRight(providerURL, "/")
+	deviceEndpoint := base + "/oauth/v2/device_authorization"
+	tokenURL := base + "/oauth/v2/token"
+
+	deviceResp, err := requestDeviceAuthorization(ctx, deviceEndpoint, clientID, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationURI := base + "/ui/v2/login/device"
+	if deviceResp.UserCode != "" {
+		verificationURI += "?user_code=" + url.QueryEscape(deviceResp.UserCode)
+	}
+
+	return &DeviceAuthSession{
+		VerificationURI: verificationURI,
+		UserCode:        deviceResp.UserCode,
+		DeviceCode:      deviceResp.DeviceCode,
+		TokenURL:        tokenURL,
+		ClientID:        clientID,
+		AuthHostname:    authHostname,
+		APIHostname:     apiHostname,
+		Interval:        deviceResp.Interval,
+		ExpiresIn:       deviceResp.ExpiresIn,
+	}, nil
+}
+
+// FinishDeviceAuth polls for the device token and completes the login by storing
+// credentials in the keyring. It returns the LoginResult on success.
+func FinishDeviceAuth(ctx context.Context, session *DeviceAuthSession, quiet bool) (*LoginResult, error) {
+	token, err := pollDeviceToken(ctx, session.TokenURL, session.ClientID, session.DeviceCode, session.Interval, session.ExpiresIn)
+	if err != nil {
+		return nil, err
+	}
+
+	providerURL := fmt.Sprintf("https://%s", session.AuthHostname)
+	provider, err := oidc.NewProvider(ctx, providerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-discover OIDC provider: %w", err)
+	}
+
+	scopes := []string{oidc.ScopeOpenID, "profile", "email", oidc.ScopeOfflineAccess}
+	return completeLogin(ctx, provider, session.ClientID, session.AuthHostname, session.APIHostname, scopes, token, false, quiet)
 }
 
 type deviceTokenResponse struct {

--- a/internal/console/components/ctxswitcher.go
+++ b/internal/console/components/ctxswitcher.go
@@ -23,11 +23,12 @@ type treeEntry struct {
 }
 
 type CtxSwitcherModel struct {
-	entries []treeEntry
-	cursor  int
-	cfg     *datumconfig.ConfigV1Beta1
-	width   int
-	height  int
+	entries      []treeEntry
+	cursor       int
+	cfg          *datumconfig.ConfigV1Beta1
+	width        int
+	height       int
+	welcomeName  string // when set, renders a personalized post-login header
 }
 
 const ctxModalWidth = 60
@@ -38,6 +39,19 @@ func NewCtxSwitcherModel(cfg *datumconfig.ConfigV1Beta1, width, height int) CtxS
 		m.entries = buildTree(cfg)
 		m.cursor = firstSelectableIdx(m.entries)
 	}
+	return m
+}
+
+// NewPostLoginCtxSwitcherModel creates a context switcher with a personalized
+// welcome header shown immediately after the user authenticates.
+func NewPostLoginCtxSwitcherModel(cfg *datumconfig.ConfigV1Beta1, width, height int, userName string) CtxSwitcherModel {
+	m := NewCtxSwitcherModel(cfg, width, height)
+	// Use first name only for warmth
+	firstName := userName
+	if i := strings.Index(userName, " "); i > 0 {
+		firstName = userName[:i]
+	}
+	m.welcomeName = firstName
 	return m
 }
 
@@ -144,8 +158,16 @@ func (m CtxSwitcherModel) View() string {
 	normalStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
 	currentStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success)
 	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted).Italic(true)
+	accent := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
+	secondary := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
 
 	var lines []string
+
+	if m.welcomeName != "" {
+		lines = append(lines, accent.Render("Welcome, "+m.welcomeName+"!"))
+		lines = append(lines, secondary.Render("Choose where you'd like to work."))
+		lines = append(lines, "")
+	}
 
 	if m.cfg == nil || len(m.cfg.Contexts) == 0 {
 		empty := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted).

--- a/internal/console/components/header.go
+++ b/internal/console/components/header.go
@@ -35,27 +35,30 @@ func (m HeaderModel) View() string {
 
 	sep := strings.Repeat("─", contentW)
 
-	infoLeft := "user: " + m.Ctx.UserEmail
-	if m.Ctx.OrgName != "" {
-		infoLeft += "   org: " + m.Ctx.OrgName
-	}
-	if m.Ctx.ProjectName != "" {
-		infoLeft += "   project: " + m.Ctx.ProjectName
-	}
-
-	infoLine := infoLeft
-	if m.Ctx.ReadOnly {
-		badge := lipgloss.NewStyle().
-			Foreground(styles.Warning).
-			Bold(true).
-			Render("READ-ONLY")
-		leftW := lipgloss.Width(infoLeft)
-		badgeW := lipgloss.Width(badge)
-		pad := contentW - leftW - badgeW
-		if pad < 1 {
-			pad = 1
+	var infoLine string
+	if m.Ctx.UserEmail != "" {
+		infoLeft := "user: " + m.Ctx.UserEmail
+		if m.Ctx.OrgName != "" {
+			infoLeft += "   org: " + m.Ctx.OrgName
 		}
-		infoLine = infoLeft + fmt.Sprintf("%*s", pad, "") + badge
+		if m.Ctx.ProjectName != "" {
+			infoLeft += "   project: " + m.Ctx.ProjectName
+		}
+
+		infoLine = infoLeft
+		if m.Ctx.ReadOnly {
+			badge := lipgloss.NewStyle().
+				Foreground(styles.Warning).
+				Bold(true).
+				Render("READ-ONLY")
+			leftW := lipgloss.Width(infoLeft)
+			badgeW := lipgloss.Width(badge)
+			pad := contentW - leftW - badgeW
+			if pad < 1 {
+				pad = 1
+			}
+			infoLine = infoLeft + fmt.Sprintf("%*s", pad, "") + badge
+		}
 	}
 
 	ns := ""

--- a/internal/console/components/loginoverlay.go
+++ b/internal/console/components/loginoverlay.go
@@ -1,0 +1,108 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"go.datum.net/datumctl/internal/console/styles"
+)
+
+// LoginOverlayState tracks which phase the device auth flow is in.
+type LoginOverlayState int
+
+const (
+	LoginOverlayInitializing LoginOverlayState = iota // waiting for device auth to start
+	LoginOverlayPending                               // device code shown, waiting for user
+	LoginOverlayComplete                              // auth succeeded (transient)
+	LoginOverlayFailed                                // auth failed
+)
+
+// LoginOverlayModel is an overlay that walks the user through the device code
+// authentication flow without leaving the TUI.
+type LoginOverlayModel struct {
+	Width  int
+	Height int
+
+	State           LoginOverlayState
+	VerificationURI string
+	UserCode        string
+	ErrMsg          string
+	SpinnerFrame    string
+}
+
+func NewLoginOverlayModel() LoginOverlayModel {
+	return LoginOverlayModel{State: LoginOverlayInitializing}
+}
+
+func (m LoginOverlayModel) View() string {
+	accent := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
+	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted)
+	secondary := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
+	success := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success).Bold(true)
+	errStyle := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Error)
+
+	var lines []string
+
+	lines = append(lines, accent.Render("Log in to Datum Cloud"))
+	lines = append(lines, "")
+
+	switch m.State {
+	case LoginOverlayInitializing:
+		lines = append(lines, muted.Render(m.SpinnerFrame+" Connecting to auth.datum.net..."))
+
+	case LoginOverlayPending:
+		lines = append(lines, secondary.Render("Open this URL in your browser:"))
+		lines = append(lines, "")
+		lines = append(lines, accent.Render("  "+m.VerificationURI))
+		lines = append(lines, "")
+		if m.UserCode != "" {
+			lines = append(lines, secondary.Render("Enter code:")+muted.Render("  ")+accent.Render(m.UserCode))
+			lines = append(lines, "")
+		}
+		lines = append(lines, muted.Render(m.SpinnerFrame+" Waiting for authentication..."))
+		lines = append(lines, "")
+		lines = append(lines, muted.Render("[b] open in browser"))
+
+	case LoginOverlayComplete:
+		lines = append(lines, success.Render("✓ Authentication successful"))
+		lines = append(lines, "")
+		lines = append(lines, muted.Render("Loading your resources..."))
+
+	case LoginOverlayFailed:
+		lines = append(lines, errStyle.Render("✗ Authentication failed"))
+		lines = append(lines, "")
+		lines = append(lines, muted.Render(m.ErrMsg))
+		lines = append(lines, "")
+		lines = append(lines, muted.Render("[Esc] dismiss   [l] try again"))
+	}
+
+	// Determine overlay width — minimum 80 so a typical verification URL fits without
+	// wrapping, then expand to fit any longer content up to terminal width minus chrome.
+	maxW := 80
+	for _, l := range lines {
+		if w := lipgloss.Width(l); w > maxW {
+			maxW = w
+		}
+	}
+	if m.Width > 0 && maxW > m.Width-8 {
+		maxW = m.Width - 8
+	}
+
+	body := strings.Join(lines, "\n")
+	return styles.OverlayStyle.Width(maxW).Render(body)
+}
+
+// StatusLine returns a one-line summary for embedding in the status bar.
+func (m LoginOverlayModel) StatusLine() string {
+	switch m.State {
+	case LoginOverlayInitializing:
+		return fmt.Sprintf("%s Connecting...", m.SpinnerFrame)
+	case LoginOverlayPending:
+		return fmt.Sprintf("%s Waiting for authentication — [b] open browser", m.SpinnerFrame)
+	case LoginOverlayFailed:
+		return "Login failed — [Esc] dismiss  [l] retry"
+	default:
+		return ""
+	}
+}

--- a/internal/console/components/loginoverlay.go
+++ b/internal/console/components/loginoverlay.go
@@ -8,6 +8,14 @@ import (
 	"go.datum.net/datumctl/internal/console/styles"
 )
 
+// loginSuccessGlyph and loginFailGlyph are the consistent status indicators
+// used in the login overlay. Keeping them as named constants ensures every
+// state line references the same character rather than scattered literals.
+const (
+	loginSuccessGlyph = "✓"
+	loginFailGlyph    = "✗"
+)
+
 // LoginOverlayState tracks which phase the device auth flow is in.
 type LoginOverlayState int
 
@@ -25,14 +33,18 @@ type LoginOverlayModel struct {
 	Height int
 
 	State           LoginOverlayState
+	AuthHostname    string // hostname shown in the initializing state line
 	VerificationURI string
 	UserCode        string
 	ErrMsg          string
 	SpinnerFrame    string
 }
 
-func NewLoginOverlayModel() LoginOverlayModel {
-	return LoginOverlayModel{State: LoginOverlayInitializing}
+func NewLoginOverlayModel(authHostname string) LoginOverlayModel {
+	return LoginOverlayModel{
+		State:        LoginOverlayInitializing,
+		AuthHostname: authHostname,
+	}
 }
 
 func (m LoginOverlayModel) View() string {
@@ -47,9 +59,14 @@ func (m LoginOverlayModel) View() string {
 	lines = append(lines, accent.Render("Log in to Datum Cloud"))
 	lines = append(lines, "")
 
+	host := m.AuthHostname
+	if host == "" {
+		host = "auth.datum.net"
+	}
+
 	switch m.State {
 	case LoginOverlayInitializing:
-		lines = append(lines, muted.Render(m.SpinnerFrame+" Connecting to auth.datum.net..."))
+		lines = append(lines, muted.Render(m.SpinnerFrame+" Connecting to "+host+"..."))
 
 	case LoginOverlayPending:
 		lines = append(lines, secondary.Render("Open this URL in your browser:"))
@@ -65,12 +82,12 @@ func (m LoginOverlayModel) View() string {
 		lines = append(lines, muted.Render("[b] open in browser"))
 
 	case LoginOverlayComplete:
-		lines = append(lines, success.Render("✓ Authentication successful"))
+		lines = append(lines, success.Render(loginSuccessGlyph+" Authentication successful"))
 		lines = append(lines, "")
 		lines = append(lines, muted.Render("Loading your resources..."))
 
 	case LoginOverlayFailed:
-		lines = append(lines, errStyle.Render("✗ Authentication failed"))
+		lines = append(lines, errStyle.Render(loginFailGlyph+" Authentication failed"))
 		lines = append(lines, "")
 		lines = append(lines, muted.Render(m.ErrMsg))
 		lines = append(lines, "")

--- a/internal/console/components/resourcetable.go
+++ b/internal/console/components/resourcetable.go
@@ -73,6 +73,7 @@ type ResourceTableModel struct {
 	// FB-005: in-pane error card state.
 	loadErr     error
 	errSeverity data.ErrorSeverity
+	notLoggedIn bool // true when loadErr is the "no active user" sentinel
 
 	// Landing-screen inputs (FB-015). These power welcomePanel() when
 	// typeName == "". Zero-values yield a safe degraded rendering.
@@ -147,16 +148,20 @@ func (m ResourceTableModel) View() string {
 	case m.loadState == data.LoadStateLoading:
 		content = m.spinner.View() + fmt.Sprintf(" Loading %s...", m.typeName)
 	case m.loadState == data.LoadStateError && m.loadErr != nil:
-		innerW := max(1, m.tableWidth-3)
-		innerH := max(1, m.tableHeight-2)
-		card := RenderErrorBlock(ErrorBlock{
-			Title:    sanitizedTitleForError(m.loadErr, "Could not load "+m.typeName),
-			Detail:   SanitizeErrMsg(m.loadErr),
-			Actions:  actionsForSeverity(m.errSeverity, "back to navigation"),
-			Severity: m.errSeverity,
-			Width:    innerW,
-		})
-		content = lipgloss.Place(innerW, innerH, lipgloss.Center, lipgloss.Center, card)
+		if m.notLoggedIn {
+			return m.renderNotLoggedInPanel(max(1, m.tableWidth), max(1, m.tableHeight))
+		} else {
+			innerW := max(1, m.tableWidth-3)
+			innerH := max(1, m.tableHeight-2)
+			card := RenderErrorBlock(ErrorBlock{
+				Title:    sanitizedTitleForError(m.loadErr, "Could not load "+m.typeName),
+				Detail:   SanitizeErrMsg(m.loadErr),
+				Actions:  actionsForSeverity(m.errSeverity, "back to navigation"),
+				Severity: m.errSeverity,
+				Width:    innerW,
+			})
+			content = lipgloss.Place(innerW, innerH, lipgloss.Center, lipgloss.Center, card)
+		}
 	case m.typeName == "" || m.forceDashboard:
 		content = m.welcomePanel()
 	case len(m.filteredRows) == 0 && m.filter != "":
@@ -176,6 +181,9 @@ func (m ResourceTableModel) View() string {
 		content = m.table.View()
 	}
 
+	if m.notLoggedIn {
+		return lipgloss.NewStyle().Background(styles.Surface).Render(styles.SurfaceFill(content, m.tableWidth, m.tableHeight))
+	}
 	return styles.PaneBorder(m.focused).Render(styles.SurfaceFill(content, m.tableWidth, m.tableHeight))
 }
 
@@ -913,6 +921,12 @@ func (m *ResourceTableModel) SetLoadErr(err error, sev data.ErrorSeverity) {
 	m.errSeverity = sev
 }
 
+// SetNotLoggedIn marks whether the current load failure is due to the user
+// not being logged in, so the error card shows login-specific messaging.
+func (m *ResourceTableModel) SetNotLoggedIn(v bool) {
+	m.notLoggedIn = v
+}
+
 func (m *ResourceTableModel) SetHoveredType(rt data.ResourceType) {
 	m.hoveredType = rt
 }
@@ -1159,4 +1173,113 @@ func (m ResourceTableModel) Cursor() int { return m.table.Cursor() }
 
 // SetCursor moves the table cursor to idx, clamped to valid range.
 func (m *ResourceTableModel) SetCursor(idx int) { m.table.SetCursor(idx) }
+
+// renderNotLoggedInPanel renders a warm welcome / login-prompt panel for
+// first-time visitors who have not yet authenticated.
+func (m ResourceTableModel) renderNotLoggedInPanel(contentW, contentH int) string {
+	accent := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
+	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted)
+	secondary := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
+	success := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success).Bold(true)
+
+	var blocks []string
+
+	blocks = append(blocks, accent.Render("Welcome to Datum Cloud"))
+
+	if contentW >= 54 {
+		blocks = append(blocks, secondary.Render("Connect infrastructure. Ship faster. Sleep better."))
+	}
+
+	if art := renderServicesArt(contentW, accent, muted, secondary); art != "" && contentH >= 14 {
+		blocks = append(blocks, art)
+	}
+
+	loginLine := success.Render("▸") + muted.Render("  ") + accent.Render("[l]") + muted.Render("  ") + secondary.Render("authenticate via device code")
+	blocks = append(blocks, loginLine)
+	blocks = append(blocks, accent.Render("[q]")+muted.Render("  quit"))
+
+	inner := lipgloss.JoinVertical(lipgloss.Center, blocks...)
+
+	// Center vertically but bias upward by half the header height (4 rows) so
+	// the block appears at the visual screen center rather than content-area center.
+	innerLines := lipgloss.Height(inner)
+	slack := max(0, contentH-innerLines)
+	vPos := lipgloss.Center
+	if slack > 0 {
+		topPad := max(0, slack/2-4)
+		vPos = lipgloss.Position(float64(topPad) / float64(slack))
+	}
+
+	return lipgloss.NewStyle().Background(styles.Surface).Render(
+		lipgloss.Place(contentW, contentH, lipgloss.Center, vPos, inner,
+			lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.Surface)),
+		),
+	)
+}
+
+// renderServicesArt returns a four-tier services box reflecting Datum's product
+// framing: Deliver, Build, Connect, Manage. Returns "" when contentW is too narrow.
+func renderServicesArt(contentW int, accent, muted, secondary lipgloss.Style) string {
+	// innerW is the content width inside the box borders.
+	// The box itself is innerW+2 cells wide (border on each side).
+	const innerW = 58
+	if contentW < innerW+4 { // need a small margin for centering
+		return ""
+	}
+
+	type tier struct {
+		name, subtitle string
+		services       string
+	}
+	tiers := []tier{
+		{
+			"DELIVER", "route users and traffic",
+			"DNS · DDoS · GLB (GeoMap) · NLB TCP/UDP · ALB",
+		},
+		{
+			"BUILD", "run apps and AI workloads",
+			"Compute · Inference · Envoy · AI Gateway · Storage · DBs",
+		},
+		{
+			"CONNECT", "private networking and reachability",
+			"VPC · Private DNS · Tunnels · Cloud Connect · ASN",
+		},
+		{
+			"MANAGE", "observe, secure, and operate",
+			"Observability · Accounts · Organization · Secrets · Billing",
+		},
+	}
+
+	// svcInnerW: content width for service lines ("  " prefix + text).
+	const svcInnerW = innerW - 2
+
+	var rows []string
+	for i, t := range tiers {
+		// Header row: ┌─/├─ NAME ─── subtitle ─...─ ┐/┤
+		lc, rc := "├", "┤"
+		if i == 0 {
+			lc, rc = "┌", "┐"
+		}
+		// Compute fill: inner = "─ NAME ─── subtitle " + fill
+		headerText := "─ " + t.name + " ─── " + t.subtitle + " "
+		fill := strings.Repeat("─", max(0, innerW-len([]rune(headerText))))
+		header := muted.Render(lc+"─ ") +
+			accent.Render(t.name) +
+			muted.Render(" ─── ") +
+			secondary.Render(t.subtitle) +
+			muted.Render(" "+fill+rc)
+		rows = append(rows, header)
+
+		// Service line: "│  services text   │"
+		svc := t.services
+		pad := strings.Repeat(" ", max(0, svcInnerW-len([]rune(svc))))
+		svcLine := muted.Render("│") + secondary.Render("  "+svc+pad) + muted.Render("│")
+		rows = append(rows, svcLine)
+	}
+	// Bottom border
+	rows = append(rows, muted.Render("└"+strings.Repeat("─", innerW)+"┘"))
+
+	return strings.Join(rows, "\n")
+}
+
 

--- a/internal/console/components/resourcetable.go
+++ b/internal/console/components/resourcetable.go
@@ -73,7 +73,6 @@ type ResourceTableModel struct {
 	// FB-005: in-pane error card state.
 	loadErr     error
 	errSeverity data.ErrorSeverity
-	notLoggedIn bool // true when loadErr is the "no active user" sentinel
 
 	// Landing-screen inputs (FB-015). These power welcomePanel() when
 	// typeName == "". Zero-values yield a safe degraded rendering.
@@ -148,20 +147,16 @@ func (m ResourceTableModel) View() string {
 	case m.loadState == data.LoadStateLoading:
 		content = m.spinner.View() + fmt.Sprintf(" Loading %s...", m.typeName)
 	case m.loadState == data.LoadStateError && m.loadErr != nil:
-		if m.notLoggedIn {
-			return m.renderNotLoggedInPanel(max(1, m.tableWidth), max(1, m.tableHeight))
-		} else {
-			innerW := max(1, m.tableWidth-3)
-			innerH := max(1, m.tableHeight-2)
-			card := RenderErrorBlock(ErrorBlock{
-				Title:    sanitizedTitleForError(m.loadErr, "Could not load "+m.typeName),
-				Detail:   SanitizeErrMsg(m.loadErr),
-				Actions:  actionsForSeverity(m.errSeverity, "back to navigation"),
-				Severity: m.errSeverity,
-				Width:    innerW,
-			})
-			content = lipgloss.Place(innerW, innerH, lipgloss.Center, lipgloss.Center, card)
-		}
+		innerW := max(1, m.tableWidth-3)
+		innerH := max(1, m.tableHeight-2)
+		card := RenderErrorBlock(ErrorBlock{
+			Title:    sanitizedTitleForError(m.loadErr, "Could not load "+m.typeName),
+			Detail:   SanitizeErrMsg(m.loadErr),
+			Actions:  actionsForSeverity(m.errSeverity, "back to navigation"),
+			Severity: m.errSeverity,
+			Width:    innerW,
+		})
+		content = lipgloss.Place(innerW, innerH, lipgloss.Center, lipgloss.Center, card)
 	case m.typeName == "" || m.forceDashboard:
 		content = m.welcomePanel()
 	case len(m.filteredRows) == 0 && m.filter != "":
@@ -181,9 +176,6 @@ func (m ResourceTableModel) View() string {
 		content = m.table.View()
 	}
 
-	if m.notLoggedIn {
-		return lipgloss.NewStyle().Background(styles.Surface).Render(styles.SurfaceFill(content, m.tableWidth, m.tableHeight))
-	}
 	return styles.PaneBorder(m.focused).Render(styles.SurfaceFill(content, m.tableWidth, m.tableHeight))
 }
 
@@ -710,7 +702,6 @@ func (m ResourceTableModel) renderHeaderBand(contentW int) string {
 	}
 }
 
-
 func (m ResourceTableModel) renderQuotaRow(r data.ConstrainedRow, width int, textOnly bool) string {
 	barStyle, suffixStyle, suffix := QuotaBarStyling(r.PercentInt)
 
@@ -919,12 +910,6 @@ func (m *ResourceTableModel) SetLoadState(s data.LoadState) {
 func (m *ResourceTableModel) SetLoadErr(err error, sev data.ErrorSeverity) {
 	m.loadErr = err
 	m.errSeverity = sev
-}
-
-// SetNotLoggedIn marks whether the current load failure is due to the user
-// not being logged in, so the error card shows login-specific messaging.
-func (m *ResourceTableModel) SetNotLoggedIn(v bool) {
-	m.notLoggedIn = v
 }
 
 func (m *ResourceTableModel) SetHoveredType(rt data.ResourceType) {
@@ -1156,7 +1141,6 @@ func (m *ResourceTableModel) applyFilter() {
 	}
 }
 
-
 func (m ResourceTableModel) SelectedRow() (data.ResourceRow, bool) {
 	if len(m.filteredRows) == 0 {
 		return data.ResourceRow{}, false
@@ -1173,113 +1157,3 @@ func (m ResourceTableModel) Cursor() int { return m.table.Cursor() }
 
 // SetCursor moves the table cursor to idx, clamped to valid range.
 func (m *ResourceTableModel) SetCursor(idx int) { m.table.SetCursor(idx) }
-
-// renderNotLoggedInPanel renders a warm welcome / login-prompt panel for
-// first-time visitors who have not yet authenticated.
-func (m ResourceTableModel) renderNotLoggedInPanel(contentW, contentH int) string {
-	accent := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
-	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted)
-	secondary := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
-	success := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success).Bold(true)
-
-	var blocks []string
-
-	blocks = append(blocks, accent.Render("Welcome to Datum Cloud"))
-
-	if contentW >= 54 {
-		blocks = append(blocks, secondary.Render("Connect infrastructure. Ship faster. Sleep better."))
-	}
-
-	if art := renderServicesArt(contentW, accent, muted, secondary); art != "" && contentH >= 14 {
-		blocks = append(blocks, art)
-	}
-
-	loginLine := success.Render("▸") + muted.Render("  ") + accent.Render("[l]") + muted.Render("  ") + secondary.Render("authenticate via device code")
-	blocks = append(blocks, loginLine)
-	blocks = append(blocks, accent.Render("[q]")+muted.Render("  quit"))
-
-	inner := lipgloss.JoinVertical(lipgloss.Center, blocks...)
-
-	// Center vertically but bias upward by half the header height (4 rows) so
-	// the block appears at the visual screen center rather than content-area center.
-	innerLines := lipgloss.Height(inner)
-	slack := max(0, contentH-innerLines)
-	vPos := lipgloss.Center
-	if slack > 0 {
-		topPad := max(0, slack/2-4)
-		vPos = lipgloss.Position(float64(topPad) / float64(slack))
-	}
-
-	return lipgloss.NewStyle().Background(styles.Surface).Render(
-		lipgloss.Place(contentW, contentH, lipgloss.Center, vPos, inner,
-			lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.Surface)),
-		),
-	)
-}
-
-// renderServicesArt returns a four-tier services box reflecting Datum's product
-// framing: Deliver, Build, Connect, Manage. Returns "" when contentW is too narrow.
-func renderServicesArt(contentW int, accent, muted, secondary lipgloss.Style) string {
-	// innerW is the content width inside the box borders.
-	// The box itself is innerW+2 cells wide (border on each side).
-	const innerW = 58
-	if contentW < innerW+4 { // need a small margin for centering
-		return ""
-	}
-
-	type tier struct {
-		name, subtitle string
-		services       string
-	}
-	tiers := []tier{
-		{
-			"DELIVER", "route users and traffic",
-			"DNS · DDoS · GLB (GeoMap) · NLB TCP/UDP · ALB",
-		},
-		{
-			"BUILD", "run apps and AI workloads",
-			"Compute · Inference · Envoy · AI Gateway · Storage · DBs",
-		},
-		{
-			"CONNECT", "private networking and reachability",
-			"VPC · Private DNS · Tunnels · Cloud Connect · ASN",
-		},
-		{
-			"MANAGE", "observe, secure, and operate",
-			"Observability · Accounts · Organization · Secrets · Billing",
-		},
-	}
-
-	// svcInnerW: content width for service lines ("  " prefix + text).
-	const svcInnerW = innerW - 2
-
-	var rows []string
-	for i, t := range tiers {
-		// Header row: ┌─/├─ NAME ─── subtitle ─...─ ┐/┤
-		lc, rc := "├", "┤"
-		if i == 0 {
-			lc, rc = "┌", "┐"
-		}
-		// Compute fill: inner = "─ NAME ─── subtitle " + fill
-		headerText := "─ " + t.name + " ─── " + t.subtitle + " "
-		fill := strings.Repeat("─", max(0, innerW-len([]rune(headerText))))
-		header := muted.Render(lc+"─ ") +
-			accent.Render(t.name) +
-			muted.Render(" ─── ") +
-			secondary.Render(t.subtitle) +
-			muted.Render(" "+fill+rc)
-		rows = append(rows, header)
-
-		// Service line: "│  services text   │"
-		svc := t.services
-		pad := strings.Repeat(" ", max(0, svcInnerW-len([]rune(svc))))
-		svcLine := muted.Render("│") + secondary.Render("  "+svc+pad) + muted.Render("│")
-		rows = append(rows, svcLine)
-	}
-	// Bottom border
-	rows = append(rows, muted.Render("└"+strings.Repeat("─", innerW)+"┘"))
-
-	return strings.Join(rows, "\n")
-}
-
-

--- a/internal/console/components/statusbar.go
+++ b/internal/console/components/statusbar.go
@@ -23,6 +23,7 @@ type StatusBarModel struct {
 	hintToken   int           // bumped on each postHint and early-clear; matched in HintClearMsg
 	Mode        StatusMode
 	Pane        string
+	NotLoggedIn bool // overrides hints with login-prompt shortcut
 }
 
 // PostHint sets a new transient hint and bumps the hint token. Returns the new
@@ -71,6 +72,10 @@ func (m StatusBarModel) View() string {
 		hints = "[j/k] move  [Enter] select  [Esc] close"
 	default:
 		modeLabel = "NORMAL"
+		if m.NotLoggedIn {
+			hints = "[l] login  [q] quit"
+			break
+		}
 		switch m.Pane {
 		case "NAV":
 			hints = "[j/k] move  [Enter] select  [r] refresh  [c] ctx  [?] help  [q] quit"
@@ -85,11 +90,18 @@ func (m StatusBarModel) View() string {
 		}
 	}
 
-	label := lipgloss.NewStyle().Bold(true).Foreground(styles.Primary).Render(modeLabel)
-	left := label + " │ " + hints
+	var left string
+	if m.NotLoggedIn {
+		left = hints
+	} else {
+		label := lipgloss.NewStyle().Bold(true).Foreground(styles.Primary).Render(modeLabel)
+		left = label + " │ " + hints
+	}
 
 	var right string
 	switch {
+	case m.NotLoggedIn:
+		right = lipgloss.NewStyle().Foreground(styles.Accent).Bold(true).Render("▸ press [l] to log in and get started")
 	case m.Err != nil:
 		g := errorGlyph(m.ErrSeverity)
 		color := errorColor(m.ErrSeverity)

--- a/internal/console/components/welcomescreen.go
+++ b/internal/console/components/welcomescreen.go
@@ -1,0 +1,88 @@
+package components
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"go.datum.net/datumctl/internal/console/styles"
+)
+
+// WelcomeScreenModel renders a full-screen welcome page shown to unauthenticated
+// users. It owns its own layout so the normal header/sidebar/table chrome is
+// skipped entirely, giving a clean centered presentation.
+type WelcomeScreenModel struct {
+	Width  int
+	Height int
+}
+
+func NewWelcomeScreenModel() WelcomeScreenModel {
+	return WelcomeScreenModel{}
+}
+
+func renderServicesTiers(accent, muted, _ lipgloss.Style) string {
+	tiers := []struct{ name, subtitle string }{
+		{"DELIVER", "route users, agents, and traffic"},
+		{"BUILD", "run apps and AI workloads"},
+		{"CONNECT", "private networking and reachability"},
+		{"MANAGE", "observe, secure, and operate"},
+	}
+	var rows []string
+	for _, t := range tiers {
+		rows = append(rows, accent.Render(t.name)+muted.Render("  "+t.subtitle))
+	}
+	return strings.Join(rows, "\n")
+}
+
+func (m WelcomeScreenModel) View() string {
+	accent := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Accent).Bold(true)
+	muted := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Muted)
+	secondary := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Secondary)
+	success := lipgloss.NewStyle().Background(styles.Surface).Foreground(styles.Success).Bold(true)
+
+	w := m.Width
+	if w <= 0 {
+		w = 80
+	}
+	h := m.Height
+	if h <= 0 {
+		h = 40
+	}
+
+	var blocks []string
+
+	// Datum wordmark — 5-line ASCII art, accent-colored
+	wordmarkLines := strings.Split(styles.DatumWordmark, "\n")
+	styledWordmark := make([]string, len(wordmarkLines))
+	for i, line := range wordmarkLines {
+		styledWordmark[i] = accent.Render(line)
+	}
+	blocks = append(blocks, strings.Join(styledWordmark, "\n"))
+	blocks = append(blocks, "")
+
+	// Title
+	blocks = append(blocks, accent.Render("Welcome to Datum Cloud"))
+	blocks = append(blocks, "")
+
+	// Tagline
+	if w >= 54 {
+		blocks = append(blocks, secondary.Render("Connect infrastructure. Ship faster. Sleep better."))
+		blocks = append(blocks, "")
+	}
+
+	// Four tiers — name + subtitle only, no service details
+	blocks = append(blocks, renderServicesTiers(accent, muted, secondary))
+	blocks = append(blocks, "")
+
+	// Action prompts
+	loginLine := success.Render("▸") + muted.Render("  ") + accent.Render("[l]") + muted.Render("  ") + secondary.Render("log in to get started")
+	blocks = append(blocks, loginLine)
+	blocks = append(blocks, accent.Render("[q]")+muted.Render("  quit"))
+
+	inner := lipgloss.JoinVertical(lipgloss.Center, blocks...)
+
+	return lipgloss.NewStyle().Background(styles.Surface).Render(
+		lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, inner,
+			lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.Surface)),
+		),
+	)
+}

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -18,7 +18,16 @@ func Run(ctx context.Context, factory *client.DatumCloudFactory, readOnly bool) 
 	}
 	consoleCtx := consolectx.FromConfig(cfg)
 	consoleCtx.ReadOnly = readOnly
-	model := NewAppModel(ctx, factory, consoleCtx)
+
+	// Derive the auth hostname from the active session so the in-TUI login
+	// overlay contacts the same endpoint the user previously authenticated
+	// against (e.g. staging). Fall back to the canonical production hostname.
+	authHostname := "auth.datum.net"
+	if s := cfg.ActiveSessionEntry(); s != nil && s.Endpoint.AuthHostname != "" {
+		authHostname = s.Endpoint.AuthHostname
+	}
+
+	model := NewAppModel(ctx, factory, consoleCtx, authHostname)
 	p := tea.NewProgram(model)
 	_, err = p.Run()
 	return err

--- a/internal/console/model.go
+++ b/internal/console/model.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/browser"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"go.datum.net/datumctl/internal/authutil"
 	"go.datum.net/datumctl/internal/client"
 	"go.datum.net/datumctl/internal/datumconfig"
+	"go.datum.net/datumctl/internal/discovery"
 	"go.datum.net/datumctl/internal/console/components"
 	tuictx "go.datum.net/datumctl/internal/console/context"
 	"go.datum.net/datumctl/internal/console/data"
@@ -41,6 +44,7 @@ const (
 	CtxSwitcherOverlay
 	HelpOverlayID
 	DeleteConfirmationOverlay // FB-017 — delete with confirmation dialog
+	LoginOverlayID            // in-TUI device auth flow
 )
 
 // DashboardOrigin stashes the pane and welcome-dashboard state at the moment
@@ -71,6 +75,61 @@ func dashboardOriginLabel(origin DashboardOrigin) string {
 		return "activity dashboard"
 	default:
 		return ""
+	}
+}
+
+// loginCompletedMsg is returned by the ExecProcess callback after `datumctl login` exits.
+type loginCompletedMsg struct{ err error }
+
+// deviceAuthStartedMsg is sent when the device authorization request succeeds
+// and the session is ready for the user to visit the URL.
+type deviceAuthStartedMsg struct {
+	session *authutil.DeviceAuthSession
+}
+
+// deviceAuthFinishedMsg is sent when polling completes (success or failure).
+type deviceAuthFinishedMsg struct {
+	result *authutil.LoginResult
+	cfg    *datumconfig.ConfigV1Beta1 // fresh config after login; nil on error
+	err    error
+}
+
+// startDeviceAuthCmd initiates the device flow in the background.
+func startDeviceAuthCmd(hostname, clientID string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		session, err := authutil.StartDeviceAuth(ctx, hostname, "", clientID)
+		if err != nil {
+			return deviceAuthFinishedMsg{err: err}
+		}
+		return deviceAuthStartedMsg{session: session}
+	}
+}
+
+// finishDeviceAuthCmd polls for the token and completes the login.
+func finishDeviceAuthCmd(session *authutil.DeviceAuthSession) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		result, err := authutil.FinishDeviceAuth(ctx, session, true)
+		if err != nil {
+			return deviceAuthFinishedMsg{err: err}
+		}
+		cfg, cfgErr := datumconfig.LoadAuto()
+		if cfgErr != nil {
+			return deviceAuthFinishedMsg{result: result, err: cfgErr}
+		}
+		s := authutil.BuildSession(result, session.AuthHostname)
+		cfg.UpsertSession(s)
+		cfg.ActiveSession = s.Name
+		tknSrc, tErr := authutil.GetTokenSourceForUser(ctx, result.UserKey)
+		if tErr == nil {
+			orgs, projects, _ := discovery.FetchOrgsAndProjects(ctx, result.APIHostname, tknSrc, result.Subject)
+			discovery.UpdateConfigCache(cfg, s.Name, orgs, projects)
+		}
+		if cfgErr = datumconfig.SaveV1Beta1(cfg); cfgErr != nil {
+			return deviceAuthFinishedMsg{result: result, err: cfgErr}
+		}
+		return deviceAuthFinishedMsg{result: result, cfg: cfg}
 	}
 }
 
@@ -137,6 +196,7 @@ type AppModel struct {
 	lastEntryViaQuickJump  bool // FB-072: set when quick-jump dispatches TablePane; cleared on sidebar interaction
 	bucketsFetchedAt    time.Time // FB-043: time of last successful bucket fetch; zero until first success
 	loadErr             error     // last error from LoadErrorMsg; used for in-pane card
+	notLoggedIn         bool      // true when loadErr is ErrNoActiveUser; triggers login-specific UX
 	lastFailedFetchKind string // "tableList" | "describe"; determines redispatchLastFetch target
 	statusErrToken      int    // bumped per LoadErrorMsg to expire stale ClearStatusErrCmd ticks
 
@@ -147,6 +207,10 @@ type AppModel struct {
 	ac                      *data.ActivityClient
 	hc                      *data.HistoryClient
 	ctx                     context.Context
+
+	// login overlay state (in-TUI device auth flow).
+	loginOverlay  components.LoginOverlayModel
+	welcomeScreen components.WelcomeScreenModel
 
 	// FB-017 delete confirmation state.
 	deleteConfirmation   components.DeleteConfirmationModel
@@ -186,10 +250,11 @@ func NewAppModel(ctx context.Context, factory *client.DatumCloudFactory, tuiCtx 
 		activityDashboard: components.NewActivityDashboardModel(40, 20, tuiCtx.ProjectName),
 		history:     components.NewHistoryViewModel(80, 20),
 		diff:        components.NewDiffViewModel(80, 20),
-		ctxOverlay:  components.NewCtxSwitcherModel(tuiCtx.Config, 80, 24),
-		filterBar:   components.NewFilterBarModel(),
-		helpOverlay: components.NewHelpOverlayModel(),
-		activePane:  NavPane,
+		ctxOverlay:    components.NewCtxSwitcherModel(tuiCtx.Config, 80, 24),
+		filterBar:     components.NewFilterBarModel(),
+		helpOverlay:   components.NewHelpOverlayModel(),
+		welcomeScreen: components.NewWelcomeScreenModel(),
+		activePane:    NavPane,
 	}
 	m.updatePaneFocus()
 	return m
@@ -238,6 +303,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case data.ResourceTypesLoadedMsg:
 		m.resourceTypes = msg.Types
 		m.loadState = data.LoadStateIdle
+		m.notLoggedIn = false
+		m.statusBar.NotLoggedIn = false
+		m.table.SetNotLoggedIn(false)
 		m.statusBar.Err = nil
 		m = m.recalcLayout() // re-sizes sidebar to terminal width with types now known
 
@@ -542,8 +610,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusBar.ErrSeverity = msg.Severity
 		m.statusErrToken++
 		cmds = append(cmds, data.ClearStatusErrCmd(m.statusErrToken, 10*time.Second))
+		m.notLoggedIn = authutil.IsNoActiveUser(msg.Err)
+		m.statusBar.NotLoggedIn = m.notLoggedIn
 		m.table.SetLoadErr(msg.Err, msg.Severity)
+		m.table.SetNotLoggedIn(m.notLoggedIn)
 		m.table.SetLoadState(data.LoadStateError)
+		if m.notLoggedIn {
+			m.updatePaneFocus()
+		}
 		if m.activePane == DetailPane {
 			// Ensure Esc from describe-error card returns to TABLE (not NavPane zero-value).
 			if m.detailReturnPane == NavPane {
@@ -566,6 +640,48 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quota.SetLoading(false)
 			m.quota.SetLoadErr(msg.Err)
 		}
+
+	case loginCompletedMsg:
+		if msg.err != nil {
+			return m, m.postHint("Login failed — run `datumctl login` in your terminal")
+		}
+		m.notLoggedIn = false
+		m.statusBar.NotLoggedIn = false
+		m.table.SetNotLoggedIn(false)
+		m.loadState = data.LoadStateLoading
+		m.statusBar.Err = nil
+		m.table.SetLoadErr(nil, data.ErrorSeverityWarning)
+		m.table.SetLoadState(data.LoadStateLoading)
+		return m, data.LoadResourceTypesCmd(m.ctx, m.rc)
+
+	case deviceAuthStartedMsg:
+		m.loginOverlay.State = components.LoginOverlayPending
+		m.loginOverlay.VerificationURI = msg.session.VerificationURI
+		m.loginOverlay.UserCode = msg.session.UserCode
+		return m, finishDeviceAuthCmd(msg.session)
+
+	case deviceAuthFinishedMsg:
+		if msg.err != nil {
+			m.loginOverlay.State = components.LoginOverlayFailed
+			m.loginOverlay.ErrMsg = msg.err.Error()
+			return m, nil
+		}
+		// Refresh TUI context from the freshly-saved config so the header shows
+		// user email, org, and project immediately after authentication.
+		if msg.cfg != nil {
+			m.tuiCtx = tuictx.FromConfig(msg.cfg)
+			m.header = components.NewHeaderModel(m.tuiCtx)
+			m.ctxOverlay = components.NewPostLoginCtxSwitcherModel(msg.cfg, m.width, m.height, msg.result.UserName)
+		}
+		m.notLoggedIn = false
+		m.statusBar.NotLoggedIn = false
+		m.table.SetNotLoggedIn(false)
+		m.statusBar.Err = nil
+		m.table.SetLoadErr(nil, data.ErrorSeverityWarning)
+		// Open the context picker so the user can choose their org/project.
+		m.overlay = CtxSwitcherOverlay
+		m.statusBar.Mode = components.ModeOverlay
+		m.updatePaneFocus()
 
 	case data.ClearStatusErrMsg:
 		if msg.Token == m.statusErrToken {
@@ -747,6 +863,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds = append(cmds, cmd)
 	m.activityDashboard, cmd = m.activityDashboard.Update(msg)
 	cmds = append(cmds, cmd)
+	if m.overlay == LoginOverlayID {
+		m.loginOverlay.SpinnerFrame = m.table.SpinnerFrame()
+	}
 	if m.refreshing {
 		frame := m.table.SpinnerFrame()
 		if m.activePane == QuotaDashboardPane {
@@ -933,6 +1052,9 @@ func (m *AppModel) updatePaneFocus() {
 		m.statusBar.PostHint("Quota dashboard cancelled") // FB-096: acknowledge nav-cancel
 		m.quotaOriginPane = DashboardOrigin{}             // FB-095: clear stale origin on nav-cancel
 	}
+	if m.notLoggedIn {
+		m.tuiCtx.ActivePaneLabel = ""
+	}
 	m.header.Ctx = m.tuiCtx
 }
 
@@ -950,15 +1072,47 @@ func (m AppModel) handleOverlayKey(msg tea.KeyMsg, _ *[]tea.Cmd) (tea.Model, tea
 
 	switch msg.String() {
 	case "esc":
-		// Esc universally dismisses all overlays. For delete-confirmation in InFlight
-		// state the API call continues; a late-arriving success still invalidates cache.
+		// For the login overlay: only allow dismissal when authentication has failed.
+		// While initializing or pending, the user must wait (or the polling will return
+		// a failure message that enables dismissal).
+		if m.overlay == LoginOverlayID {
+			if m.loginOverlay.State == components.LoginOverlayFailed {
+				m.overlay = NoOverlay
+				m.statusBar.Mode = components.ModeNormal
+			}
+			return m, nil
+		}
+		// Esc universally dismisses all other overlays. For delete-confirmation in
+		// InFlight state the API call continues; a late-arriving success still
+		// invalidates cache.
 		m.overlay = NoOverlay
 		m.statusBar.Mode = components.ModeNormal
 		return m, nil
+	case "l":
+		// Allow retrying from the failed login overlay state.
+		if m.overlay == LoginOverlayID && m.loginOverlay.State == components.LoginOverlayFailed {
+			clientID, err := authutil.ResolveClientID("", "auth.datum.net")
+			if err != nil {
+				return m, m.postHint("Could not resolve client ID: " + err.Error())
+			}
+			m.loginOverlay = components.NewLoginOverlayModel()
+			m.loginOverlay.Width = m.width
+			m.loginOverlay.Height = m.height
+			return m, startDeviceAuthCmd("auth.datum.net", clientID)
+		}
+	case "b":
+		// Open the verification URL in the system browser when the device code is showing.
+		if m.overlay == LoginOverlayID && m.loginOverlay.State == components.LoginOverlayPending {
+			url := m.loginOverlay.VerificationURI
+			return m, func() tea.Msg {
+				_ = browser.OpenURL(url)
+				return nil
+			}
+		}
 	case "?":
 		// `?` closes CtxSwitcher/Help, but NOT DeleteConfirmation — the operator must
 		// make an explicit Y/N/Esc decision on a pending delete.
-		if m.overlay != DeleteConfirmationOverlay {
+		if m.overlay != DeleteConfirmationOverlay && m.overlay != LoginOverlayID {
 			m.overlay = NoOverlay
 			m.statusBar.Mode = components.ModeNormal
 			return m, nil
@@ -1316,9 +1470,26 @@ func (m AppModel) handleNormalKey(msg tea.KeyMsg, _ *[]tea.Cmd) (tea.Model, tea.
 		m.overlay = CtxSwitcherOverlay
 		m.statusBar.Mode = components.ModeOverlay
 		return m, nil
+	case "l":
+		if m.notLoggedIn || (m.overlay == LoginOverlayID && m.loginOverlay.State == components.LoginOverlayFailed) {
+			clientID, err := authutil.ResolveClientID("", "auth.datum.net")
+			if err != nil {
+				return m, m.postHint("Could not resolve client ID: " + err.Error())
+			}
+			m.overlay = LoginOverlayID
+			m.loginOverlay = components.NewLoginOverlayModel()
+			m.loginOverlay.Width = m.width
+			m.loginOverlay.Height = m.height
+			m.statusBar.Mode = components.ModeOverlay
+			return m, startDeviceAuthCmd("auth.datum.net", clientID)
+		}
 	case "r":
 		// FB-005 §4: error-state branch MUST run before the normal-state refresh branch.
 		if m.loadState == data.LoadStateError {
+			if m.notLoggedIn {
+				m.statusBar.Err = nil
+				return m, m.postHint("Not logged in — press [l] to login")
+			}
 			sev := components.ErrorSeverityOf(m.loadErr, m.rc)
 			if sev == data.ErrorSeverityError {
 				// P1: clear statusBar.Err so hint wins the statusbar switch (Err branch
@@ -2238,6 +2409,9 @@ func (m AppModel) activeConsumer() (kind, name string) {
 
 func (m AppModel) recalcLayout() AppModel {
 	sidebarWidth := layout.SidebarWidth(m.width)
+	if m.notLoggedIn {
+		sidebarWidth = 0
+	}
 
 	filterVisible := m.filterBar.Focused()
 	mainH := layout.MainAreaWithFilter(m.height, filterVisible)
@@ -2248,9 +2422,15 @@ func (m AppModel) recalcLayout() AppModel {
 	// fits exactly within the allocated pane footprint.
 	sidebarInnerW, sidebarInnerH := styles.PaneInnerSize(sidebarWidth, mainH)
 	tableInnerW, tableInnerH := styles.PaneInnerSize(tableW, mainH)
+	if m.notLoggedIn {
+		// No PaneBorder chrome when showing the welcome screen — give the full width.
+		tableInnerW = tableW
+	}
 
 	m.header.Width = m.width
 	m.statusBar.Width = m.width
+	m.welcomeScreen.Width = m.width
+	m.welcomeScreen.Height = max(1, m.height-layout.FooterHeight)
 
 	newSidebar := components.NewNavSidebarModel(sidebarInnerW, sidebarInnerH)
 	newSidebar.SetItems(m.resourceTypes)
@@ -2305,6 +2485,30 @@ func (m AppModel) recalcLayout() AppModel {
 }
 
 func (m AppModel) View() tea.View {
+	// Unauthenticated users get a dedicated full-screen welcome page — skip the
+	// normal header/sidebar/table chrome entirely.
+	if m.notLoggedIn {
+		m.welcomeScreen.Height = m.height
+		welcome := styles.SurfaceFill(m.welcomeScreen.View(), m.width, m.height)
+		base := welcome
+
+		var content string
+		switch m.overlay {
+		case LoginOverlayID:
+			content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+				m.loginOverlay.View(),
+				lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.OverlayBackdrop)),
+			)
+		default:
+			content = lipgloss.Place(m.width, m.height, lipgloss.Left, lipgloss.Top, base,
+				lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.Surface)),
+			)
+		}
+		v := tea.NewView(content)
+		v.AltScreen = true
+		return v
+	}
+
 	header := m.header.View()
 
 	var mainContent string
@@ -2341,10 +2545,14 @@ func (m AppModel) View() tea.View {
 		)
 	default:
 		rightCol := m.tableView()
-		mainContent = lipgloss.JoinHorizontal(lipgloss.Top,
-			m.sidebar.View(),
-			rightCol,
-		)
+		if m.notLoggedIn {
+			mainContent = rightCol
+		} else {
+			mainContent = lipgloss.JoinHorizontal(lipgloss.Top,
+				m.sidebar.View(),
+				rightCol,
+			)
+		}
 	}
 
 	status := m.statusBar.View()
@@ -2378,6 +2586,11 @@ func (m AppModel) View() tea.View {
 		)
 	case DeleteConfirmationOverlay:
 		content = m.deleteConfirmation.View(m.width, m.height)
+	case LoginOverlayID:
+		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+			m.loginOverlay.View(),
+			lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.OverlayBackdrop)),
+		)
 	default:
 		// Paint any slack area outside the composed layout with the Surface color
 		// so the console reads as dark mode regardless of the terminal background.

--- a/internal/console/model.go
+++ b/internal/console/model.go
@@ -8,20 +8,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/browser"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/pkg/browser"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"go.datum.net/datumctl/internal/authutil"
 	"go.datum.net/datumctl/internal/client"
-	"go.datum.net/datumctl/internal/datumconfig"
-	"go.datum.net/datumctl/internal/discovery"
 	"go.datum.net/datumctl/internal/console/components"
 	tuictx "go.datum.net/datumctl/internal/console/context"
 	"go.datum.net/datumctl/internal/console/data"
 	"go.datum.net/datumctl/internal/console/layout"
 	"go.datum.net/datumctl/internal/console/styles"
+	"go.datum.net/datumctl/internal/datumconfig"
+	"go.datum.net/datumctl/internal/discovery"
 )
 
 type PaneID int
@@ -78,9 +78,6 @@ func dashboardOriginLabel(origin DashboardOrigin) string {
 	}
 }
 
-// loginCompletedMsg is returned by the ExecProcess callback after `datumctl login` exits.
-type loginCompletedMsg struct{ err error }
-
 // deviceAuthStartedMsg is sent when the device authorization request succeeds
 // and the session is ready for the user to visit the URL.
 type deviceAuthStartedMsg struct {
@@ -95,9 +92,8 @@ type deviceAuthFinishedMsg struct {
 }
 
 // startDeviceAuthCmd initiates the device flow in the background.
-func startDeviceAuthCmd(hostname, clientID string) tea.Cmd {
+func startDeviceAuthCmd(ctx context.Context, hostname, clientID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
 		session, err := authutil.StartDeviceAuth(ctx, hostname, "", clientID)
 		if err != nil {
 			return deviceAuthFinishedMsg{err: err}
@@ -107,9 +103,8 @@ func startDeviceAuthCmd(hostname, clientID string) tea.Cmd {
 }
 
 // finishDeviceAuthCmd polls for the token and completes the login.
-func finishDeviceAuthCmd(session *authutil.DeviceAuthSession) tea.Cmd {
+func finishDeviceAuthCmd(ctx context.Context, session *authutil.DeviceAuthSession) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
 		result, err := authutil.FinishDeviceAuth(ctx, session, true)
 		if err != nil {
 			return deviceAuthFinishedMsg{err: err}
@@ -207,6 +202,7 @@ type AppModel struct {
 	ac                      *data.ActivityClient
 	hc                      *data.HistoryClient
 	ctx                     context.Context
+	authHostname            string // auth server hostname for in-TUI device flow
 
 	// login overlay state (in-TUI device auth flow).
 	loginOverlay  components.LoginOverlayModel
@@ -224,7 +220,7 @@ type AppModel struct {
 	activityOriginPane DashboardOrigin // FB-048/FB-087: stash before opening ActivityDashboard
 }
 
-func NewAppModel(ctx context.Context, factory *client.DatumCloudFactory, tuiCtx tuictx.TUIContext) AppModel {
+func NewAppModel(ctx context.Context, factory *client.DatumCloudFactory, tuiCtx tuictx.TUIContext, authHostname string) AppModel {
 	krc := data.NewKubeResourceClient(factory)
 	rrc := data.NewKubeResourceRegistrationClient(factory)
 	var rc data.ResourceClient = krc
@@ -232,14 +228,15 @@ func NewAppModel(ctx context.Context, factory *client.DatumCloudFactory, tuiCtx 
 	ac := data.NewActivityClient(factory)
 	hc := data.NewHistoryClient(factory)
 	m := AppModel{
-		ctx:         ctx,
-		factory:     factory,
-		rc:          rc,
-		bc:          bc,
-		rrc:         rrc,
-		ac:          ac,
-		hc:          hc,
-		tuiCtx:      tuiCtx,
+		ctx:          ctx,
+		authHostname: authHostname,
+		factory:      factory,
+		rc:           rc,
+		bc:           bc,
+		rrc:          rrc,
+		ac:           ac,
+		hc:           hc,
+		tuiCtx:       tuiCtx,
 		header:      components.NewHeaderModel(tuiCtx),
 		sidebar:     components.NewNavSidebarModel(styles.SidebarWidth, 20),
 		table:       components.NewResourceTableModel(40, 20),
@@ -305,7 +302,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadState = data.LoadStateIdle
 		m.notLoggedIn = false
 		m.statusBar.NotLoggedIn = false
-		m.table.SetNotLoggedIn(false)
 		m.statusBar.Err = nil
 		m = m.recalcLayout() // re-sizes sidebar to terminal width with types now known
 
@@ -613,7 +609,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.notLoggedIn = authutil.IsNoActiveUser(msg.Err)
 		m.statusBar.NotLoggedIn = m.notLoggedIn
 		m.table.SetLoadErr(msg.Err, msg.Severity)
-		m.table.SetNotLoggedIn(m.notLoggedIn)
 		m.table.SetLoadState(data.LoadStateError)
 		if m.notLoggedIn {
 			m.updatePaneFocus()
@@ -641,29 +636,16 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quota.SetLoadErr(msg.Err)
 		}
 
-	case loginCompletedMsg:
-		if msg.err != nil {
-			return m, m.postHint("Login failed — run `datumctl login` in your terminal")
-		}
-		m.notLoggedIn = false
-		m.statusBar.NotLoggedIn = false
-		m.table.SetNotLoggedIn(false)
-		m.loadState = data.LoadStateLoading
-		m.statusBar.Err = nil
-		m.table.SetLoadErr(nil, data.ErrorSeverityWarning)
-		m.table.SetLoadState(data.LoadStateLoading)
-		return m, data.LoadResourceTypesCmd(m.ctx, m.rc)
-
 	case deviceAuthStartedMsg:
 		m.loginOverlay.State = components.LoginOverlayPending
 		m.loginOverlay.VerificationURI = msg.session.VerificationURI
 		m.loginOverlay.UserCode = msg.session.UserCode
-		return m, finishDeviceAuthCmd(msg.session)
+		return m, finishDeviceAuthCmd(m.ctx, msg.session)
 
 	case deviceAuthFinishedMsg:
 		if msg.err != nil {
 			m.loginOverlay.State = components.LoginOverlayFailed
-			m.loginOverlay.ErrMsg = msg.err.Error()
+			m.loginOverlay.ErrMsg = components.SanitizeErrMsg(msg.err)
 			return m, nil
 		}
 		// Refresh TUI context from the freshly-saved config so the header shows
@@ -675,13 +657,15 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.notLoggedIn = false
 		m.statusBar.NotLoggedIn = false
-		m.table.SetNotLoggedIn(false)
 		m.statusBar.Err = nil
 		m.table.SetLoadErr(nil, data.ErrorSeverityWarning)
 		// Open the context picker so the user can choose their org/project.
+		// Also start loading resource types so the console is ready if the user
+		// dismisses the picker without selecting a context.
 		m.overlay = CtxSwitcherOverlay
 		m.statusBar.Mode = components.ModeOverlay
 		m.updatePaneFocus()
+		return m, data.LoadResourceTypesCmd(m.ctx, m.rc)
 
 	case data.ClearStatusErrMsg:
 		if msg.Token == m.statusErrToken {
@@ -1091,14 +1075,14 @@ func (m AppModel) handleOverlayKey(msg tea.KeyMsg, _ *[]tea.Cmd) (tea.Model, tea
 	case "l":
 		// Allow retrying from the failed login overlay state.
 		if m.overlay == LoginOverlayID && m.loginOverlay.State == components.LoginOverlayFailed {
-			clientID, err := authutil.ResolveClientID("", "auth.datum.net")
+			clientID, err := authutil.ResolveClientID("", m.authHostname)
 			if err != nil {
 				return m, m.postHint("Could not resolve client ID: " + err.Error())
 			}
-			m.loginOverlay = components.NewLoginOverlayModel()
+			m.loginOverlay = components.NewLoginOverlayModel(m.authHostname)
 			m.loginOverlay.Width = m.width
 			m.loginOverlay.Height = m.height
-			return m, startDeviceAuthCmd("auth.datum.net", clientID)
+			return m, startDeviceAuthCmd(m.ctx, m.authHostname, clientID)
 		}
 	case "b":
 		// Open the verification URL in the system browser when the device code is showing.
@@ -1472,16 +1456,16 @@ func (m AppModel) handleNormalKey(msg tea.KeyMsg, _ *[]tea.Cmd) (tea.Model, tea.
 		return m, nil
 	case "l":
 		if m.notLoggedIn || (m.overlay == LoginOverlayID && m.loginOverlay.State == components.LoginOverlayFailed) {
-			clientID, err := authutil.ResolveClientID("", "auth.datum.net")
+			clientID, err := authutil.ResolveClientID("", m.authHostname)
 			if err != nil {
 				return m, m.postHint("Could not resolve client ID: " + err.Error())
 			}
 			m.overlay = LoginOverlayID
-			m.loginOverlay = components.NewLoginOverlayModel()
+			m.loginOverlay = components.NewLoginOverlayModel(m.authHostname)
 			m.loginOverlay.Width = m.width
 			m.loginOverlay.Height = m.height
 			m.statusBar.Mode = components.ModeOverlay
-			return m, startDeviceAuthCmd("auth.datum.net", clientID)
+			return m, startDeviceAuthCmd(m.ctx, m.authHostname, clientID)
 		}
 	case "r":
 		// FB-005 §4: error-state branch MUST run before the normal-state refresh branch.
@@ -2489,12 +2473,13 @@ func (m AppModel) View() tea.View {
 	// normal header/sidebar/table chrome entirely.
 	if m.notLoggedIn {
 		m.welcomeScreen.Height = m.height
-		welcome := styles.SurfaceFill(m.welcomeScreen.View(), m.width, m.height)
-		base := welcome
+		base := styles.SurfaceFill(m.welcomeScreen.View(), m.width, m.height)
 
 		var content string
 		switch m.overlay {
 		case LoginOverlayID:
+			// Place the login overlay centered over the welcome screen so users
+			// can see the welcome content behind the auth dialog.
 			content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
 				m.loginOverlay.View(),
 				lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(styles.OverlayBackdrop)),

--- a/internal/console/model.go
+++ b/internal/console/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -105,7 +106,7 @@ func startDeviceAuthCmd(ctx context.Context, hostname, clientID string) tea.Cmd 
 // finishDeviceAuthCmd polls for the token and completes the login.
 func finishDeviceAuthCmd(ctx context.Context, session *authutil.DeviceAuthSession) tea.Cmd {
 	return func() tea.Msg {
-		result, err := authutil.FinishDeviceAuth(ctx, session, true)
+		result, err := authutil.FinishDeviceAuth(ctx, session, io.Discard)
 		if err != nil {
 			return deviceAuthFinishedMsg{err: err}
 		}


### PR DESCRIPTION
## What's new

Before this change, opening the console without an active session showed a generic error with no clear path forward. Now:

- **A welcome screen greets you** with a clear prompt to log in — no more dead ends
- **Log in without leaving the console** — press `[l]` to start a device authorization flow right inside the TUI
- **Follow the link or let the console open it** — press `[b]` to open the verification URL in your browser automatically
- **Seamless handoff on success** — once authenticated, the context picker opens so you can get straight to work

The sidebar and status bar adapt throughout the login flow so hints are always relevant to what you're doing.

## Demo


https://github.com/user-attachments/assets/19786394-99a2-424e-9188-83ac8299fd56

## Test plan

- [ ] Open `datumctl console` without logging in — verify the welcome screen appears
- [ ] Press `[l]` — verify the device auth overlay appears with a verification URL
- [ ] Press `[b]` — verify the URL opens in a browser
- [ ] Complete login in the browser — verify the context picker opens automatically
- [ ] Open `datumctl console` with an active session — verify normal console experience is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)