### PR TITLE
Update index.md with `brew trust` call for newer versions of `brew`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,9 @@ install `datumctl` via our official tap:
 # Tap the Datum Cloud formula repository (only needs to be done once)
 brew tap datum-cloud/homebrew-tap
 
+# Trust the datumctl formula
+brew trust --formula datum-cloud/homebrew-tap/datumctl
+
 # Install datumctl
 brew install datumctl
 


### PR DESCRIPTION
Add a trust call for newer versions of brew https://docs.brew.sh/Tap-Trust. 

Just tapping and installing without trusting on newer versions of brew causes the following error.

```
brew install datumctl
Error: Refusing to load formula datum-cloud/tap/datumctl from untrusted tap datum-cloud/tap.
Run `brew trust --formula datum-cloud/tap/datumctl` or `brew trust datum-cloud/tap` to trust it.
```