### PR TITLE
fix: non-standard SPDX license

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,7 @@ nfpms:
   - vendor: Datum Technology, Inc
     homepage: https://www.datum.net/
     maintainer: support@datum.net
-    license: Apache 2.0
+    license: Apache-2.0
     provides:
     - datumctl
     recommends:
@@ -92,7 +92,7 @@ brews:
   directory: Formula
   homepage: "https://www.datum.net/"
   description: "A network cloud, built on open source."
-  license: "Apache 2.0"
+  license: "Apache-2.0"
   repository:
     owner: datum-cloud
     name: homebrew-tap


### PR DESCRIPTION
`brew audit --cask desktop --tap datum-cloud/tap` is failing for, among other things outside of this repo, containing a non-standard license

```shell
  * Formula datumctl contains non-standard SPDX licenses: ["Apache 2.0"].
    For a list of valid licenses check: https://spdx.org/licenses/
```

`Apache-2.0` is the valid license syntax.