### PR TITLE
feat: add --exec-interactive-mode to auth update-kubeconfig

### DIFF
--- a/internal/cmd/auth/update-kubeconfig.go
+++ b/internal/cmd/auth/update-kubeconfig.go
@@ -13,7 +13,7 @@ import (
 )
 
 func updateKubeconfigCmd() *cobra.Command {
-	var kubeconfig, projectName, organizationName, hostname string
+	var kubeconfig, projectName, organizationName, hostname, execInteractiveMode string
 
 	cmd := &cobra.Command{
 		Use:   "update-kubeconfig",
@@ -47,8 +47,20 @@ environments where the hostname cannot be derived from stored credentials).`,
   datumctl auth update-kubeconfig --project my-project-id
 
   # Write to a custom kubeconfig file
-  datumctl auth update-kubeconfig --organization my-org-id --kubeconfig ~/.kube/datum-config`,
+  datumctl auth update-kubeconfig --organization my-org-id --kubeconfig ~/.kube/datum-config
+
+  # Non-interactive exec credential (CI / scripts)
+  datumctl auth update-kubeconfig --project my-project-id --exec-interactive-mode Never`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			interactiveMode := api.ExecInteractiveMode(execInteractiveMode)
+			switch interactiveMode {
+			case api.NeverExecInteractiveMode, api.IfAvailableExecInteractiveMode, api.AlwaysExecInteractiveMode:
+			default:
+				return fmt.Errorf("invalid --exec-interactive-mode %q: must be one of %s, %s, %s",
+					execInteractiveMode,
+					api.NeverExecInteractiveMode, api.IfAvailableExecInteractiveMode, api.AlwaysExecInteractiveMode)
+			}
+
 			// Determine kubeconfig path
 			var kubeconfigPath string
 			if kubeconfig != "" {
@@ -143,7 +155,7 @@ environments where the hostname cannot be derived from stored credentials).`,
 					Args:               execArgs,
 					APIVersion:         "client.authentication.k8s.io/v1",
 					ProvideClusterInfo: false,
-					InteractiveMode:    "IfAvailable",
+					InteractiveMode:    interactiveMode,
 				},
 			}
 
@@ -166,6 +178,9 @@ environments where the hostname cannot be derived from stored credentials).`,
 	cmd.Flags().StringVar(&projectName, "project", "", "Configure kubectl to access a specific project's control plane instead of the core control plane.")
 	cmd.Flags().StringVar(&organizationName, "organization", "", "The organization name that is being connected to.")
 	cmd.Flags().StringVar(&hostname, "hostname", "", "Override the hostname for the API server")
+	cmd.Flags().StringVar(&execInteractiveMode, "exec-interactive-mode", string(api.IfAvailableExecInteractiveMode),
+		fmt.Sprintf("Interactive mode for the kubeconfig exec credential plugin (%s, %s, %s). Use %s for non-interactive contexts such as CI.",
+			api.NeverExecInteractiveMode, api.IfAvailableExecInteractiveMode, api.AlwaysExecInteractiveMode, api.NeverExecInteractiveMode))
 
 	cmd.MarkFlagsOneRequired("project", "organization")
 	cmd.MarkFlagsMutuallyExclusive("project", "organization")

--- a/internal/cmd/auth/update-kubeconfig_test.go
+++ b/internal/cmd/auth/update-kubeconfig_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestUpdateKubeconfigExecInteractiveMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    api.ExecInteractiveMode
+		wantErr bool
+	}{
+		{
+			name: "default is IfAvailable",
+			args: []string{"--project", "p", "--hostname", "https://api.example.test"},
+			want: api.IfAvailableExecInteractiveMode,
+		},
+		{
+			name: "Never",
+			args: []string{"--project", "p", "--hostname", "https://api.example.test", "--exec-interactive-mode", "Never"},
+			want: api.NeverExecInteractiveMode,
+		},
+		{
+			name: "Always",
+			args: []string{"--project", "p", "--hostname", "https://api.example.test", "--exec-interactive-mode", "Always"},
+			want: api.AlwaysExecInteractiveMode,
+		},
+		{
+			name:    "invalid value rejected",
+			args:    []string{"--project", "p", "--hostname", "https://api.example.test", "--exec-interactive-mode", "Bogus"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeconfigPath := filepath.Join(t.TempDir(), "config")
+			cmd := updateKubeconfigCmd()
+			cmd.SetArgs(append(tc.args, "--kubeconfig", kubeconfigPath))
+
+			err := cmd.Execute()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			cfg, err := clientcmd.LoadFromFile(kubeconfigPath)
+			if err != nil {
+				t.Fatalf("failed to load written kubeconfig: %v", err)
+			}
+			user, ok := cfg.AuthInfos["datum-user"]
+			if !ok || user.Exec == nil {
+				t.Fatal("datum-user exec auth info not written")
+			}
+			if user.Exec.InteractiveMode != tc.want {
+				t.Errorf("InteractiveMode = %q, want %q", user.Exec.InteractiveMode, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `--exec-interactive-mode` to `datumctl auth update-kubeconfig`, letting callers set the exec credential plugin's `interactiveMode` directly instead of the hardcoded `IfAvailable`.

Closes #220.

## Why

Non-interactive contexts (CI, scripts) have no TTY. The `IfAvailable` default forces callers to patch the generated kubeconfig after the fact:

```
datumctl auth update-kubeconfig --project p ...
kubectl --kubeconfig ... config set-credentials datum-user --exec-interactive-mode=Never
```

In `datum-cloud/infra` that patch is duplicated across ~15 Chainsaw test sites (datum-cloud/infra#2806). This flag removes the need for it.

## Changes

- Add `--exec-interactive-mode` accepting `Never` / `IfAvailable` / `Always`
- Default `IfAvailable` — no behavior change for existing callers
- Validate the value; error on anything else
- Table test covering default, each valid mode, and rejection

## Validation

```
$ datumctl auth update-kubeconfig --project p --hostname https://api.example.test \
    --exec-interactive-mode Never --kubeconfig /tmp/kc
$ grep interactiveMode /tmp/kc
      interactiveMode: Never

$ datumctl auth update-kubeconfig --project p --exec-interactive-mode Bogus
error: invalid --exec-interactive-mode "Bogus": must be one of Never, IfAvailable, Always
```

`go build ./...`, `go vet`, and `go test ./internal/cmd/auth/` all pass.
