### PR TITLE
Forward flags to trusted plugins the same way as installed plugins

### DIFF
--- a/internal/plugindispatch/forward.go
+++ b/internal/plugindispatch/forward.go
@@ -17,12 +17,18 @@ import (
 	"go.datum.net/datumctl/internal/pluginstore"
 )
 
-// ForwardPlugin checks whether os.Args represents a managed-plugin invocation and,
-// if so, replaces the current process with the plugin binary before cobra can
-// parse (and discard) flags that belong to the plugin's own subcommands.
+// ForwardPlugin checks whether os.Args represents a plugin invocation and, if so,
+// replaces the current process with the plugin binary before cobra can parse (and
+// discard) flags that belong to the plugin's own subcommands. This verbatim
+// forwarding is what lets "datumctl <plugin> <subcmd> -o wide" work without the
+// caller having to insert a "--" separator.
 //
-// It only execs managed plugins (found in pluginsDir). PATH-based plugins reach
-// the same destination via the root RunE, where trust-checking also runs.
+// It execs both managed plugins (found in pluginsDir, gated by a SHA256 integrity
+// check) and trusted PATH plugins (milo-<name>/datumctl-<name>, gated by the same
+// pluginstore.IsTrusted check the help/completion forward paths and the root RunE
+// use). An untrusted or unknown PATH binary is left for cobra, where the root RunE
+// surfaces the "has not been trusted" guidance — it is never exec'd or handed
+// DATUM_* credentials from here.
 //
 // Must be called after the cobra command tree is fully built so that IsBuiltIn
 // can correctly distinguish plugin names from registered subcommands.
@@ -39,14 +45,32 @@ func ForwardPlugin(pluginsDir string, root *cobra.Command, factory *client.Datum
 	}
 
 	binaryPath, managed, err := FindPlugin(name, pluginsDir)
-	if err != nil || !managed {
+	if err != nil {
+		// Not a known plugin in the managed dir or on PATH — let cobra handle it.
 		return nil
 	}
 
-	// Verify the on-disk binary's SHA256 matches the recorded manifest entry.
-	// This guards against the binary being silently replaced after install.
-	if verifyErr := VerifyManagedPluginIntegrity(pluginsDir, name, binaryPath); verifyErr != nil {
-		return verifyErr
+	if managed {
+		// Verify the on-disk binary's SHA256 matches the recorded manifest entry.
+		// This guards against the binary being silently replaced after install.
+		if verifyErr := VerifyManagedPluginIntegrity(pluginsDir, name, binaryPath); verifyErr != nil {
+			return verifyErr
+		}
+	} else {
+		// Unmanaged PATH plugin. Trust must be established BEFORE exec because Exec
+		// injects DATUM_CREDENTIALS_HELPER; an untrusted binary must never reach it.
+		// Resolve symlinks once so the trust check and the subsequent exec act on
+		// the same real path (TOCTOU defense, matching the root RunE and the
+		// help/completion forward paths).
+		if abs, absErr := filepath.EvalSymlinks(binaryPath); absErr == nil {
+			binaryPath = abs
+		}
+		if !pluginstore.IsTrusted(pluginsDir, name, binaryPath) {
+			// Untrusted/unknown binary: fall through to cobra unchanged. The root
+			// RunE surfaces the "has not been trusted" guidance; do not exec or
+			// inject credentials here.
+			return nil
+		}
 	}
 
 	return Exec(binaryPath, args[1:], factory)

--- a/internal/plugindispatch/forward_passthrough_test.go
+++ b/internal/plugindispatch/forward_passthrough_test.go
@@ -1,0 +1,203 @@
+package plugindispatch
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"go.datum.net/datumctl/internal/pluginstore"
+)
+
+// TestForwardPlugin_trustedPathPlugin_forwardsArgs is the regression test for
+// issue #240: a trusted PATH plugin (datumctl-<name> / milo-<name>) must receive
+// its full argument list verbatim, exactly like a managed plugin, so that flags
+// belonging to the plugin's own subcommands (e.g. "-o wide") are not rejected by
+// cobra as unknown datumctl flags. Before the fix, ForwardPlugin returned early
+// for unmanaged plugins and the args fell through to cobra, which required an
+// undocumented "--" separator.
+//
+// execPlatform is overridden so the plugin is not actually exec'd (which would
+// replace the test process); we capture the binary path and args instead.
+func TestForwardPlugin_trustedPathPlugin_forwardsArgs(t *testing.T) {
+	// Not parallel — mutates os.Args, execPlatform, and environment.
+	pathDir := t.TempDir()
+	managedDir := t.TempDir()
+
+	binaryPath := writeFakeBinary(t, pathDir, "datumctl-search")
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+origPath)
+
+	// Trust the plugin: record its symlink-resolved path + SHA256 in plugins.json,
+	// which is exactly what `datumctl plugin trust` writes.
+	resolved, err := filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	writeManifest(t, managedDir, &pluginstore.Manifest{
+		Trusted: map[string]*pluginstore.TrustedEntry{
+			"search": {Path: resolved, SHA256: sha256HexFile(t, resolved)},
+		},
+	})
+
+	var gotBinary string
+	var gotArgs []string
+	execCalled := false
+	origExec := execPlatform
+	execPlatform = func(binary string, args []string, _ []string) error {
+		execCalled = true
+		gotBinary = binary
+		gotArgs = args
+		return nil
+	}
+	t.Cleanup(func() { execPlatform = origExec })
+
+	orig := os.Args
+	os.Args = []string{"datumctl", "search", "kinds", "-o", "wide"}
+	t.Cleanup(func() { os.Args = orig })
+
+	factory := buildMinimalFactory(t)
+	root := buildMinimalCobraTree()
+
+	if err := ForwardPlugin(managedDir, root, factory); err != nil {
+		t.Fatalf("ForwardPlugin: unexpected error: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("trusted PATH plugin was not exec'd; args fall through to cobra and -o is rejected")
+	}
+	if gotBinary != resolved {
+		t.Errorf("exec binary = %q, want symlink-resolved trusted path %q", gotBinary, resolved)
+	}
+	wantArgs := []string{"kinds", "-o", "wide"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Errorf("forwarded args = %v, want %v (verbatim, no -- separator)", gotArgs, wantArgs)
+	}
+}
+
+// TestForwardPlugin_untrustedPathPlugin_notExeced verifies the security invariant:
+// an unmanaged PATH binary that has NOT been trusted is never exec'd and never
+// handed DATUM_* credentials by ForwardPlugin. It falls through (returns nil) so
+// cobra's root RunE can surface the "has not been trusted" guidance unchanged.
+func TestForwardPlugin_untrustedPathPlugin_notExeced(t *testing.T) {
+	// Not parallel — mutates os.Args, execPlatform, and environment.
+	pathDir := t.TempDir()
+	managedDir := t.TempDir()
+
+	writeFakeBinary(t, pathDir, "datumctl-search")
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", pathDir+string(os.PathListSeparator)+origPath)
+
+	// No plugins.json trust entry and no env-var override — IsTrusted is false.
+	t.Setenv("DATUMCTL_TRUSTED_PLUGINS", "")
+
+	execCalled := false
+	origExec := execPlatform
+	execPlatform = func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	}
+	t.Cleanup(func() { execPlatform = origExec })
+
+	orig := os.Args
+	os.Args = []string{"datumctl", "search", "kinds"}
+	t.Cleanup(func() { os.Args = orig })
+
+	root := buildMinimalCobraTree()
+
+	// factory is nil: this path must return before Exec, so BuildEnv is never
+	// reached. A non-nil return or an exec here would be a security regression.
+	if err := ForwardPlugin(managedDir, root, nil); err != nil {
+		t.Fatalf("ForwardPlugin untrusted PATH plugin: want nil (fall through), got %v", err)
+	}
+	if execCalled {
+		t.Fatal("untrusted PATH binary was exec'd; it must fall through to cobra without credential injection")
+	}
+}
+
+// TestForwardPlugin_managedPlugin_forwardsArgs verifies the managed path is
+// untouched by the unmanaged-trust refactor: a recorded managed plugin whose
+// SHA256 matches is still exec'd with its args forwarded verbatim.
+func TestForwardPlugin_managedPlugin_forwardsArgs(t *testing.T) {
+	// Not parallel — mutates os.Args, execPlatform, and environment.
+	managedDir := t.TempDir()
+	// Isolate PATH so only the managed binary resolves the plugin name.
+	t.Setenv("PATH", t.TempDir())
+
+	bin := writeFakeBinary(t, managedDir, "ipam")
+	recordManaged(t, managedDir, "ipam", sha256HexFile(t, bin))
+
+	var gotBinary string
+	var gotArgs []string
+	execCalled := false
+	origExec := execPlatform
+	execPlatform = func(binary string, args []string, _ []string) error {
+		execCalled = true
+		gotBinary = binary
+		gotArgs = args
+		return nil
+	}
+	t.Cleanup(func() { execPlatform = origExec })
+
+	orig := os.Args
+	os.Args = []string{"datumctl", "ipam", "allocate", "-o", "json"}
+	t.Cleanup(func() { os.Args = orig })
+
+	factory := buildMinimalFactory(t)
+	root := buildMinimalCobraTree()
+
+	if err := ForwardPlugin(managedDir, root, factory); err != nil {
+		t.Fatalf("ForwardPlugin managed plugin: unexpected error: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("managed plugin was not exec'd")
+	}
+	wantBinary, _ := filepath.Abs(bin)
+	if gotBinary != wantBinary {
+		t.Errorf("exec binary = %q, want %q", gotBinary, wantBinary)
+	}
+	wantArgs := []string{"allocate", "-o", "json"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Errorf("forwarded args = %v, want %v", gotArgs, wantArgs)
+	}
+}
+
+// TestForwardPlugin_managedTamperedBinary_returnsError verifies the managed
+// integrity check still fails closed inside ForwardPlugin: a managed binary whose
+// bytes changed after the SHA256 was recorded is rejected (returned as an error)
+// rather than exec'd.
+func TestForwardPlugin_managedTamperedBinary_returnsError(t *testing.T) {
+	// Not parallel — mutates os.Args, execPlatform, and environment.
+	managedDir := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+
+	bin := writeFakeBinary(t, managedDir, "ipam")
+	recordManaged(t, managedDir, "ipam", sha256HexFile(t, bin))
+	// Swap the bytes after recording the hash.
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho pwned\n"), 0o755); err != nil {
+		t.Fatalf("rewrite binary: %v", err)
+	}
+
+	execCalled := false
+	origExec := execPlatform
+	execPlatform = func(_ string, _ []string, _ []string) error {
+		execCalled = true
+		return nil
+	}
+	t.Cleanup(func() { execPlatform = origExec })
+
+	orig := os.Args
+	os.Args = []string{"datumctl", "ipam", "allocate"}
+	t.Cleanup(func() { os.Args = orig })
+
+	root := buildMinimalCobraTree()
+
+	err := ForwardPlugin(managedDir, root, buildMinimalFactory(t))
+	if err == nil {
+		t.Fatal("tampered managed binary must return an error, got nil")
+	}
+	if execCalled {
+		t.Fatal("tampered managed binary must not be exec'd")
+	}
+}


### PR DESCRIPTION
Fixes #240

## What changed

Running a trusted plugin through datumctl now hands the plugin its full command line, exactly as if the plugin had been installed from a catalog. Before this change, datumctl tried to parse a trusted plugin's flags itself and rejected any it didn't recognize, so a command the plugin's own help advertises — `datumctl search kinds -o wide` — died on datumctl's usage screen unless the user knew to insert a `--` separator. Catalog-installed plugins never had this problem, which meant the same binary behaved differently depending on how it was registered, and the plugin took the blame for a dispatch quirk.

Now `datumctl <plugin> <anything…>` delivers `<anything…>` to the plugin verbatim, whether the plugin was installed from a catalog or trusted from PATH.

## What didn't change

Trust is still the gate. A binary that hasn't been explicitly trusted or installed is never executed and never receives credentials — it gets the same refusal and `datumctl plugin trust` guidance as before. Catalog-installed plugins keep their integrity verification.

## Behavior notes

Two side effects of parity, both matching how installed plugins already behave, worth a line in release notes:

- datumctl's own scope flags (such as `--organization` and `--project`) placed after a trusted plugin's name are now delivered to the plugin rather than consumed by datumctl. Plugins define their own scope flags; the environment datumctl injects reflects the active context.
- A `--` separator after the plugin name now reaches the plugin, which may assign it its own meaning. The separator is no longer needed to get flags through.

## Verification

- New tests cover the trusted, untrusted, and installed dispatch paths, including proof that an untrusted binary is never executed.
- Verified manually: a trusted plugin's flags pass through with no separator, an untrusted binary on PATH is refused with the existing guidance, and a catalog-installed plugin behaves identically before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
