### PR TITLE
fix: correct stale 'datumctl auth login' references

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ DATUM_PROJECT=my-project datumctl get dnszones
 DATUM_ORGANIZATION=my-org datumctl get projects
 ```
 
-`--project` and `--organization` flags work too. For machine-to-machine auth, see `datumctl auth login --credentials` for the machine-account flow.
+`--project` and `--organization` flags work too. For machine-to-machine auth, see `datumctl login --credentials` for the machine-account flow.
 
 ## Agent Skills
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -22,7 +22,7 @@ You need an API key from one of the supported LLM providers:
 You also need to be logged in to Datum Cloud:
 
 ```
-datumctl auth login
+datumctl login
 ```
 
 ## Quick start

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,9 +10,9 @@ API keys directly.
 
 Authentication involves the following commands:
 
-*   `datumctl auth login`
+*   `datumctl login`
 *   `datumctl auth list`
-*   `datumctl auth logout`
+*   `datumctl logout`
 *   `datumctl auth get-token`
 *   `datumctl auth update-kubeconfig`
 *   `datumctl auth switch`
@@ -25,7 +25,7 @@ keyring.
 To authenticate with Datum Cloud, use the `login` command:
 
 ```
-datumctl auth login [--hostname <auth-hostname>] [--no-browser] [-v]
+datumctl login [--hostname <auth-hostname>] [--no-browser] [-v]
 ```
 
 *   `--hostname <auth-hostname>`: (Optional) Specify the hostname of the Datum
@@ -116,7 +116,7 @@ To remove stored credentials, use the `logout` command.
 **Log out a specific user:**
 
 ```
-datumctl auth logout <user-email>
+datumctl logout <user-email>
 ```
 
 Replace `<user-email>` with the email address shown in the
@@ -125,7 +125,7 @@ Replace `<user-email>` with the email address shown in the
 **Log out all users:**
 
 ```
-datumctl auth logout --all
+datumctl logout --all
 ```
 
 This removes all Datum Cloud credentials stored by `datumctl` in your keyring.

--- a/docs/developer/authentication_flow.md
+++ b/docs/developer/authentication_flow.md
@@ -6,10 +6,10 @@ sidebar:
 
 `datumctl` utilizes OAuth 2.0 Authorization Code Flow with PKCE (Proof Key for
 Code Exchange) for user authentication. This flow is orchestrated by the
-`datumctl auth login` command and leverages OpenID Connect (OIDC) for
+`datumctl login` command and leverages OpenID Connect (OIDC) for
 discovering provider endpoints and verifying user identity.
 
-## Login process (`datumctl auth login`)
+## Login process (`datumctl login`)
 
 The following diagram illustrates the sequence of events during login:
 
@@ -21,7 +21,7 @@ sequenceDiagram
     participant OSKeyring as OS Keyring
     participant DatumAuth as Datum Cloud Auth Server
 
-    User->>+Datumctl: datumctl auth login [--hostname AUTH_HOST]
+    User->>+Datumctl: datumctl login [--hostname AUTH_HOST]
     Datumctl->>DatumAuth: OIDC Discovery (using AUTH_HOST)
     DatumAuth-->>Datumctl: OIDC Endpoints (Authorization, Token)
     Datumctl->>Datumctl: Generate PKCE Code Verifier & Challenge

--- a/internal/authutil/credentials.go
+++ b/internal/authutil/credentials.go
@@ -27,7 +27,7 @@ const KnownUsersKey = "known_users"
 // ErrNoActiveUser indicates that no active user is set in the keyring.
 var ErrNoActiveUser = customerrors.NewUserErrorWithHint(
 	"No active user found.",
-	"Please login first using: `datumctl auth login`",
+	"Please login first using: `datumctl login`",
 )
 
 // IsNoActiveUser reports whether err wraps ErrNoActiveUser.
@@ -145,7 +145,7 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 			if retrieveErr.ErrorCode == "invalid_grant" || retrieveErr.ErrorCode == "invalid_request" {
 				return nil, customerrors.WrapUserErrorWithHint(
 					"Authentication session has expired or refresh token is no longer valid.",
-					"Please re-authenticate using: `datumctl auth login`",
+					"Please re-authenticate using: `datumctl login`",
 					err,
 				)
 			}

--- a/internal/authutil/login.go
+++ b/internal/authutil/login.go
@@ -201,7 +201,7 @@ func runPKCEFlow(ctx context.Context, provider *oidc.Provider, clientID string, 
 		fmt.Println("Please visit this URL manually to authenticate:")
 		fmt.Printf("\n%s\n\n", authURL)
 		fmt.Println("Tip: in a headless environment (CI, SSH without forwarding, or a container) use")
-		fmt.Println("'datumctl auth login --no-browser' — it uses a device-code flow that doesn't need a local browser.")
+		fmt.Println("'datumctl login --no-browser' — it uses a device-code flow that doesn't need a local browser.")
 	} else {
 		fmt.Println("Please complete the authentication in your browser.")
 	}

--- a/internal/authutil/serviceaccount.go
+++ b/internal/authutil/serviceaccount.go
@@ -205,7 +205,7 @@ func (m *serviceAccountTokenSource) Token() (*oauth2.Token, error) {
 		if readErr != nil {
 			return nil, customerrors.WrapUserErrorWithHint(
 				"failed to read service account private key from "+sa.PrivateKeyPath,
-				"re-run 'datumctl auth login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
+				"re-run 'datumctl login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
 				readErr,
 			)
 		}
@@ -213,7 +213,7 @@ func (m *serviceAccountTokenSource) Token() (*oauth2.Token, error) {
 	if pemKey == "" {
 		return nil, customerrors.WrapUserErrorWithHint(
 			"service account session is missing its private key",
-			"re-run 'datumctl auth login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
+			"re-run 'datumctl login --credentials <file>'; you may need to download a new service account credentials file from the Datum portal if the original is no longer available",
 			nil,
 		)
 	}
@@ -222,7 +222,7 @@ func (m *serviceAccountTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, customerrors.WrapUserErrorWithHint(
 			"Failed to mint JWT for service account authentication.",
-			"Please re-authenticate using: `datumctl auth login --credentials <file>`",
+			"Please re-authenticate using: `datumctl login --credentials <file>`",
 			err,
 		)
 	}
@@ -231,7 +231,7 @@ func (m *serviceAccountTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, customerrors.WrapUserErrorWithHint(
 			"Failed to exchange JWT for access token.",
-			"Please re-authenticate using: `datumctl auth login --credentials <file>`",
+			"Please re-authenticate using: `datumctl login --credentials <file>`",
 			err,
 		)
 	}

--- a/internal/client/factory.go
+++ b/internal/client/factory.go
@@ -343,7 +343,7 @@ func NewDatumFactory(ctx context.Context) (*DatumCloudFactory, error) {
 		config, err := NewRestConfig(ctx)
 		if err != nil {
 			// Return a broken config so the error surfaces at request time
-			// (e.g. "please run datumctl auth login") rather than crashing
+			// (e.g. "please run datumctl login") rather than crashing
 			// the process — which is especially important during shell completion.
 			return &rest.Config{Host: "http://localhost:0"}
 		}

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -23,7 +23,7 @@ Advanced — kubectl integration:
   If you use kubectl and want to point it at a Datum Cloud control plane,
   see 'datumctl auth update-kubeconfig --help'.`,
 		Example: `  # Log in to Datum Cloud
-  datumctl auth login
+  datumctl login
 
   # Show all logged-in accounts
   datumctl auth list
@@ -32,7 +32,7 @@ Advanced — kubectl integration:
   datumctl auth switch user@example.com
 
   # Log out a specific account
-  datumctl auth logout user@example.com`,
+  datumctl logout user@example.com`,
 	}
 
 	cmd.AddCommand(

--- a/internal/cmd/auth/get_token.go
+++ b/internal/cmd/auth/get_token.go
@@ -91,7 +91,7 @@ func runGetToken(cmd *cobra.Command, args []string) error {
 		tokenSource, err = authutil.GetTokenSource(ctx)
 		if err != nil {
 			if errors.Is(err, authutil.ErrNoActiveUser) {
-				return errors.New("no active user found in keyring. Please login first using 'datumctl auth login'")
+				return errors.New("no active user found in keyring. Please login first using 'datumctl login'")
 			}
 			return fmt.Errorf("failed to get token source: %w", err)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -252,7 +252,7 @@ Get started:
 
 	// Top-level auth entry points. Promoted out of the 'auth' subgroup so that
 	// new users find 'datumctl login' at the root of the CLI, while experienced
-	// users can still reach 'datumctl auth login' for advanced options
+	// users can still reach 'datumctl login' for advanced options
 	// (service-account, device flow).
 	loginCmd := login.Command()
 	loginCmd.GroupID = "auth"

--- a/skills/datumctl/SKILL.md
+++ b/skills/datumctl/SKILL.md
@@ -26,7 +26,7 @@ commands directly.
 
 - Authenticate with `datumctl login` for interactive use.
 - For headless or automation workflows, prefer machine-account authentication
-  via `datumctl auth login --credentials <file>`.
+  via `datumctl login --credentials <file>`.
 - Most resource commands need either an active context or explicit
   `--organization` / `--project` flags.
 - Prefer `-o json` or `-o yaml` when another tool or agent needs structured


### PR DESCRIPTION
Fixes the text half of #243.

## Problem

`datumctl auth` help, several user-facing error hints, and the docs point users at `datumctl auth login` / `datumctl auth logout` — subcommands that don't exist. Login and logout live at the top level (`datumctl login` / `datumctl logout`). Running the wrong spelling silently reprints the group help with exit code 0, so a user gets no signal the command is invalid.

## Changes

- **`internal/cmd/auth/auth.go`** — Examples block now uses `datumctl login` / `datumctl logout`.
- **Error hints** — corrected the same wrong spelling in the failure paths across `internal/authutil/{credentials,login,serviceaccount}.go`, `internal/cmd/auth/get_token.go`, `internal/cmd/root.go`, and `internal/client/factory.go` (keyring / credentials / service-account / token-exchange messages that tell users how to re-authenticate).
- **Docs & skill sweep** — `README.md`, `docs/ai.md`, `docs/authentication.md`, `docs/developer/authentication_flow.md`, `skills/datumctl/SKILL.md`.

Text/doc only — no behavior change. `datumctl auth list` / `switch` / `get-token` / `update-kubeconfig` references left as-is (those really are under `auth`).

## Verification

```
$ datumctl auth
...
Examples:
  # Log in to Datum Cloud
  datumctl login
  ...
  # Log out a specific account
  datumctl logout user@example.com
```

`go build ./...` and `go vet ./internal/...` pass.

## Follow-up (not in this PR)

The exit-0 silent-fallthrough hardening from #243 (fail loud on unknown `auth` subcommand, or register `login`/`logout` aliases) is a behavior change and will be a separate PR.