### PR TITLE
fix: hard-error on unknown 'auth' subcommands

### DIFF
--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -1,11 +1,24 @@
 package auth
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	customerrors "go.datum.net/datumctl/internal/errors"
 )
 
-// Command creates the base "auth" command and adds subcommands for login,
-// logout, token retrieval, etc.
+// movedCommands maps subcommands that used to live under "auth" to their
+// current top-level spelling. Login and logout were promoted to top-level
+// commands in the context-discovery redesign (#149); users following older
+// docs or muscle memory still reach for "datumctl auth login".
+var movedCommands = map[string]string{
+	"login":  "datumctl login",
+	"logout": "datumctl logout",
+}
+
+// Command creates the base "auth" command and adds subcommands for session
+// management, token retrieval, and kubectl integration.
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
@@ -33,6 +46,13 @@ Advanced — kubectl integration:
 
   # Log out a specific account
   datumctl logout user@example.com`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			return unknownSubcommandError(args[0])
+		},
 	}
 
 	cmd.AddCommand(
@@ -43,4 +63,22 @@ Advanced — kubectl integration:
 	)
 
 	return cmd
+}
+
+// unknownSubcommandError turns an unrecognized "datumctl auth <name>" into a
+// hard error instead of a silently-successful help dump. Names that were moved
+// to the top level get a hint pointing at the replacement command.
+func unknownSubcommandError(name string) error {
+	if replacement, moved := movedCommands[name]; moved {
+		return &customerrors.UserError{
+			Message: fmt.Sprintf("'datumctl auth %s' is now '%s'", name, replacement),
+			Hint:    fmt.Sprintf("Login and logout are top-level commands — run '%s'.", replacement),
+			Code:    "AUTH_COMMAND_MOVED",
+		}
+	}
+	return &customerrors.UserError{
+		Message: fmt.Sprintf("unknown command %q for 'datumctl auth'", name),
+		Hint:    "Run 'datumctl auth --help' for available commands.",
+		Code:    "UNKNOWN_SUBCOMMAND",
+	}
 }

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	customerrors "go.datum.net/datumctl/internal/errors"
+)
+
+func TestAuthUnknownSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantErr  bool
+		wantCode string
+		wantHint string
+	}{
+		{
+			name: "bare auth shows help",
+			args: []string{},
+		},
+		{
+			name:     "moved login errors with top-level hint",
+			args:     []string{"login"},
+			wantErr:  true,
+			wantCode: "AUTH_COMMAND_MOVED",
+			wantHint: "datumctl login",
+		},
+		{
+			name:     "moved logout errors with top-level hint",
+			args:     []string{"logout"},
+			wantErr:  true,
+			wantCode: "AUTH_COMMAND_MOVED",
+			wantHint: "datumctl logout",
+		},
+		{
+			name:     "unknown subcommand errors generically",
+			args:     []string{"bogus"},
+			wantErr:  true,
+			wantCode: "UNKNOWN_SUBCOMMAND",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := Command()
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			userErr, ok := customerrors.IsUserError(err)
+			if !ok {
+				t.Fatalf("expected *UserError, got %T: %v", err, err)
+			}
+			if userErr.Code != tc.wantCode {
+				t.Errorf("Code = %q, want %q", userErr.Code, tc.wantCode)
+			}
+			if tc.wantHint != "" && !strings.Contains(userErr.Hint, tc.wantHint) {
+				t.Errorf("Hint = %q, want it to contain %q", userErr.Hint, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestAuthValidSubcommandStillRoutes(t *testing.T) {
+	cmd := Command()
+	sub, _, err := cmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("Find(list) returned error: %v", err)
+	}
+	if sub.Name() != "list" {
+		t.Fatalf("expected to resolve the 'list' subcommand, got %q", sub.Name())
+	}
+}


### PR DESCRIPTION
Second half of #243. **Stacked on #244** — base is `fix/auth-help-stale-login-examples`; review/merge #244 first, then this retargets to `main`.

## Problem

`datumctl auth login` and `datumctl auth logout` don't error. Cobra treats the unknown subcommand as a positional arg, the `auth` group has no `RunE`, so it reprints the group help and **exits 0**. A user following old docs or muscle memory gets no signal the command is invalid — and (before #244) the help they saw repeated the wrong spelling.

Login/logout were deliberately promoted to top-level commands in the context-discovery redesign (#149, PR #149); they are not coming back under `auth`. So the fix is to fail loudly and redirect, not to re-add aliases.

## Change

`auth` now validates its args (`cobra.ArbitraryArgs` + `RunE`):

- **Moved commands** (`login`, `logout`) → targeted error with a hint at the replacement:
  ```
  $ datumctl auth login
  error: 'datumctl auth login' is now 'datumctl login'
  Log in and log out are top-level commands — run 'datumctl login'.
  $ echo $?
  1
  ```
- **Any other unknown subcommand** → generic error pointing at `--help`:
  ```
  $ datumctl auth bogus
  error: unknown command "bogus" for 'datumctl auth'
  Run 'datumctl auth --help' for available commands.
  ```
- **Bare `datumctl auth`** → still prints help, exits 0.
- **Valid subcommands** (`list`, `switch`, `get-token`, `update-kubeconfig`) route unchanged.

Both errors carry a machine-readable `Code` (`AUTH_COMMAND_MOVED`, `UNKNOWN_SUBCOMMAND`) so structured (`--error-format json`) consumers and agents can branch on them:

```
$ datumctl auth logout --error-format json
{"error":{"code":"AUTH_COMMAND_MOVED","message":"'datumctl auth logout' is now 'datumctl logout'","hint":"...","retryable":false}}
```

## Tests

`internal/cmd/auth/auth_test.go` covers bare-auth-help, both moved-command hints, the generic unknown case, and that valid subcommands still resolve. `go build ./...` and `go test ./internal/cmd/auth/...` pass.