### PR TITLE
Keep whoami honest about which environment you're in

### DIFF
--- a/internal/cmd/auth/switch.go
+++ b/internal/cmd/auth/switch.go
@@ -84,11 +84,14 @@ func runSwitch(_ *cobra.Command, args []string) error {
 
 	cfg.ActiveSession = sessionName
 
-	// Restore last context for this session.
-	if session.LastContext != "" {
-		if cfg.ContextByName(session.LastContext) != nil {
-			cfg.CurrentContext = session.LastContext
-		}
+	// Repoint the current context at the new session's last context so whoami
+	// and requests follow the switch. Clear it when the new session has no
+	// usable context, letting the ActiveSession fallback take over rather than
+	// leaving a stale context from the previous environment selected.
+	if session.LastContext != "" && cfg.ContextByName(session.LastContext) != nil {
+		cfg.CurrentContext = session.LastContext
+	} else {
+		cfg.CurrentContext = ""
 	}
 
 	if err := datumconfig.SaveV1Beta1(cfg); err != nil {

--- a/internal/cmd/ctx/ctx.go
+++ b/internal/cmd/ctx/ctx.go
@@ -19,8 +19,9 @@ func Command() *cobra.Command {
 		Short: "View and switch contexts",
 		Long: `List and switch between organizations and projects.
 
-Running 'datumctl ctx' without a subcommand lists all available contexts
-for the current user. Use --refresh to update the context cache from the API.`,
+Running 'datumctl ctx' without a subcommand lists the active session's
+contexts. Use --all to list every session's contexts grouped by account and
+endpoint, or --refresh to update the context cache from the API.`,
 		Aliases: []string{"context"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if refresh {
@@ -40,6 +41,7 @@ for the current user. Use --refresh to update the context cache from the API.`,
 	}
 
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh the context cache from the API before listing")
+	cmd.Flags().Bool("all", false, "List contexts from every session, grouped by account and endpoint")
 
 	cmd.AddCommand(listCmd())
 	cmd.AddCommand(useCmd())

--- a/internal/cmd/ctx/list.go
+++ b/internal/cmd/ctx/list.go
@@ -12,16 +12,23 @@ import (
 )
 
 func listCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List available contexts",
+		Long: `List the contexts for the active session.
+
+By default only the active session's contexts are shown. Use --all to list
+every session's contexts grouped by account and endpoint — useful when the
+same organization or project name exists in more than one environment.`,
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,
 		RunE:    runList,
 	}
+	cmd.Flags().Bool("all", false, "List contexts from every session, grouped by account and endpoint")
+	return cmd
 }
 
-func runList(_ *cobra.Command, _ []string) error {
+func runList(cmd *cobra.Command, _ []string) error {
 	cfg, err := datumconfig.LoadAuto()
 	if err != nil {
 		return err
@@ -32,7 +39,17 @@ func runList(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	printContextTree(os.Stdout, cfg)
+	all, _ := cmd.Flags().GetBool("all")
+	if all {
+		printAllContexts(os.Stdout, cfg)
+		return nil
+	}
+
+	activeSession := ""
+	if s := cfg.ActiveSessionEntry(); s != nil {
+		activeSession = s.Name
+	}
+	printContextTree(os.Stdout, cfg, activeSession)
 	return nil
 }
 
@@ -42,13 +59,34 @@ type orgGroup struct {
 	projects []*datumconfig.DiscoveredContext
 }
 
-func printContextTree(w io.Writer, cfg *datumconfig.ConfigV1Beta1) {
+// printAllContexts lists every session's contexts, grouped by account and
+// endpoint so overlapping refs across environments stay distinguishable.
+func printAllContexts(w io.Writer, cfg *datumconfig.ConfigV1Beta1) {
+	for i := range cfg.Sessions {
+		s := &cfg.Sessions[i]
+		if len(cfg.ContextsForSession(s.Name)) == 0 {
+			continue
+		}
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s  (%s)\n", s.UserEmail, datumconfig.StripScheme(s.Endpoint.Server))
+		printContextTree(w, cfg, s.Name)
+	}
+}
+
+// printContextTree prints the contexts owned by sessionName as an org/project
+// tree. Display names are resolved within that session.
+func printContextTree(w io.Writer, cfg *datumconfig.ConfigV1Beta1, sessionName string) {
 	// Group contexts by org.
 	groups := make(map[string]*orgGroup)
 	var orgOrder []string
 
 	for i := range cfg.Contexts {
 		ctx := &cfg.Contexts[i]
+		if ctx.Session != sessionName {
+			continue
+		}
 		orgID := ctx.OrganizationID
 
 		g, ok := groups[orgID]
@@ -83,7 +121,7 @@ func printContextTree(w io.Writer, cfg *datumconfig.ConfigV1Beta1) {
 			if cfg.CurrentContext == g.orgCtx.Name {
 				current = "*"
 			}
-			tbl.AddRow(cfg.OrgDisplayName(orgID), orgID, "org", current)
+			tbl.AddRow(cfg.OrgDisplayName(sessionName, orgID), orgID, "org", current)
 		}
 
 		for _, p := range g.projects {
@@ -91,7 +129,7 @@ func printContextTree(w io.Writer, cfg *datumconfig.ConfigV1Beta1) {
 			if cfg.CurrentContext == p.Name {
 				current = "*"
 			}
-			tbl.AddRow("  "+cfg.ProjectDisplayName(p.ProjectID), p.Ref(), "project", current)
+			tbl.AddRow("  "+cfg.ProjectDisplayName(sessionName, p.ProjectID), p.Ref(), "project", current)
 		}
 	}
 

--- a/internal/cmd/ctx/use.go
+++ b/internal/cmd/ctx/use.go
@@ -34,18 +34,34 @@ func runUse(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Contexts are addressed relative to the active session, since the same
+	// org/project ref can exist in more than one environment.
+	activeSession := ""
+	if s := cfg.ActiveSessionEntry(); s != nil {
+		activeSession = s.Name
+	}
+	sessionContexts := cfg.ContextsForSession(activeSession)
+
 	var resolved *datumconfig.DiscoveredContext
 
 	if len(args) == 1 {
-		resolved = cfg.ResolveContext(args[0])
+		resolved = cfg.ResolveContextInSession(args[0], activeSession)
 		if resolved == nil {
+			// The ref may belong to a different environment's session — point the
+			// user at that session rather than a bare "not found".
+			if owner := cfg.FindContextOwner(args[0], activeSession); owner != nil {
+				return customerrors.NewUserErrorWithHint(
+					fmt.Sprintf("Context %q belongs to the session for %s, which is not active.", args[0], owner.UserEmail),
+					fmt.Sprintf("Run 'datumctl auth switch %s' first, then 'datumctl ctx use %s'.", owner.UserEmail, args[0]),
+				)
+			}
 			return customerrors.NewUserErrorWithHint(
 				fmt.Sprintf("Context %q not found.", args[0]),
 				"Run 'datumctl ctx' to see available contexts.",
 			)
 		}
 	} else {
-		selected, err := picker.SelectContext(cfg.Contexts, cfg)
+		selected, err := picker.SelectContext(sessionContexts, cfg)
 		if err != nil {
 			return err
 		}
@@ -57,6 +73,9 @@ func runUse(_ *cobra.Command, args []string) error {
 	}
 
 	cfg.CurrentContext = resolved.Name
+	// The active session is always the current context's session; keep the
+	// stored fallback in lockstep so whoami and requests never diverge.
+	cfg.ActiveSession = resolved.Session
 
 	if s := cfg.SessionByName(resolved.Session); s != nil {
 		s.LastContext = resolved.Name

--- a/internal/cmd/landing.go
+++ b/internal/cmd/landing.go
@@ -79,10 +79,10 @@ func printLoggedInLanding(out io.Writer, cfg *datumconfig.ConfigV1Beta1, session
 	if ctxEntry != nil {
 		var ctxLine string
 		if ctxEntry.ProjectID != "" {
-			projName := cfg.ProjectDisplayName(ctxEntry.ProjectID)
+			projName := cfg.ProjectDisplayName(ctxEntry.Session, ctxEntry.ProjectID)
 			ctxLine = fmt.Sprintf("%q project (%s)", projName, ctxEntry.Ref())
 		} else {
-			orgName := cfg.OrgDisplayName(ctxEntry.OrganizationID)
+			orgName := cfg.OrgDisplayName(ctxEntry.Session, ctxEntry.OrganizationID)
 			ctxLine = fmt.Sprintf("%q org (%s)", orgName, ctxEntry.OrganizationID)
 		}
 		fmt.Fprintf(out, "  Context        %s\n", ctxLine)

--- a/internal/cmd/whoami/whoami.go
+++ b/internal/cmd/whoami/whoami.go
@@ -61,11 +61,11 @@ func runWhoami(_ *cobra.Command, _ []string) error {
 		fmt.Printf("Context:      %s\n", ctxEntry.Ref())
 
 		fmt.Printf("Organization: %s\n", datumconfig.FormatWithID(
-			cfg.OrgDisplayName(ctxEntry.OrganizationID), ctxEntry.OrganizationID))
+			cfg.OrgDisplayName(ctxEntry.Session, ctxEntry.OrganizationID), ctxEntry.OrganizationID))
 
 		if ctxEntry.ProjectID != "" {
 			fmt.Printf("Project:      %s\n", datumconfig.FormatWithID(
-				cfg.ProjectDisplayName(ctxEntry.ProjectID), ctxEntry.ProjectID))
+				cfg.ProjectDisplayName(ctxEntry.Session, ctxEntry.ProjectID), ctxEntry.ProjectID))
 		}
 	} else {
 		fmt.Println("Context:      (none)")

--- a/internal/console/components/ctxswitcher.go
+++ b/internal/console/components/ctxswitcher.go
@@ -75,7 +75,7 @@ func buildTree(cfg *datumconfig.ConfigV1Beta1) []treeEntry {
 
 	var entries []treeEntry
 	for _, orgID := range orgOrder {
-		orgName := cfg.OrgDisplayName(orgID)
+		orgName := cfg.OrgDisplayName(activeSession, orgID)
 		entries = append(entries, treeEntry{isHeader: true, label: orgName})
 		for i := range cfg.Contexts {
 			ctx := &cfg.Contexts[i]
@@ -87,7 +87,7 @@ func buildTree(cfg *datumconfig.ConfigV1Beta1) []treeEntry {
 			}
 			var label string
 			if ctx.ProjectID != "" {
-				label = cfg.ProjectDisplayName(ctx.ProjectID)
+				label = cfg.ProjectDisplayName(ctx.Session, ctx.ProjectID)
 			} else {
 				label = "(org-wide)"
 			}

--- a/internal/console/context/context.go
+++ b/internal/console/context/context.go
@@ -45,10 +45,10 @@ func FromConfig(cfg *datumconfig.ConfigV1Beta1) TUIContext {
 		tc.UserName = session.UserName
 	}
 
-	tc.OrgName = cfg.OrgDisplayName(ctx.OrganizationID)
+	tc.OrgName = cfg.OrgDisplayName(ctx.Session, ctx.OrganizationID)
 
 	if ctx.ProjectID != "" {
-		tc.ProjectName = cfg.ProjectDisplayName(ctx.ProjectID)
+		tc.ProjectName = cfg.ProjectDisplayName(ctx.Session, ctx.ProjectID)
 	}
 
 	return tc

--- a/internal/datumconfig/config_v1beta1.go
+++ b/internal/datumconfig/config_v1beta1.go
@@ -49,8 +49,13 @@ type Endpoint struct {
 	CertificateAuthorityData string `json:"certificate-authority-data,omitempty" yaml:"certificate-authority-data,omitempty"`
 }
 
-// DiscoveredContext is a context entry derived from the API. Names follow the
-// format "orgID" for org-scoped or "orgID/projectID" for project-scoped.
+// DiscoveredContext is a context entry derived from the API.
+//
+// Name is a session-qualified unique key of the form "session/ref" (see
+// QualifiedContextName). Because org and project IDs overlap across
+// environments — staging and production can both expose "datum/datum-cloud" —
+// the bare Ref() is only unique within a single session, so the stored Name
+// carries the owning session to keep entries from different logins distinct.
 type DiscoveredContext struct {
 	Name           string `json:"name" yaml:"name"`
 	Session        string `json:"session" yaml:"session"`
@@ -59,14 +64,27 @@ type DiscoveredContext struct {
 	Namespace      string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
-// Ref returns the canonical reference string for this context — "orgID" for org
-// contexts or "orgID/projectID" for project contexts. This is the value users
-// pass to "datumctl ctx use".
+// Ref returns the canonical, session-relative reference string for this context
+// — "orgID" for org contexts or "orgID/projectID" for project contexts. This is
+// the value users pass to "datumctl ctx use". It is unique only within a
+// session; use Name (or QualifiedContextName) for a globally-unique key.
 func (c *DiscoveredContext) Ref() string {
 	if c.ProjectID != "" {
 		return c.OrganizationID + "/" + c.ProjectID
 	}
 	return c.OrganizationID
+}
+
+// QualifiedContextName builds the session-qualified unique key for a context
+// from its owning session name and its session-relative ref. Session names
+// never contain "/", so the first segment always recovers the session.
+func QualifiedContextName(sessionName, ref string) string {
+	return sessionName + "/" + ref
+}
+
+// QualifiedName returns the session-qualified unique key for this context.
+func (c *DiscoveredContext) QualifiedName() string {
+	return QualifiedContextName(c.Session, c.Ref())
 }
 
 // FormatWithID returns "displayName (resourceID)" when the display name differs
@@ -81,26 +99,14 @@ func FormatWithID(displayName, resourceID string) string {
 
 // DisplayRef returns a human-friendly label for this context, using cached
 // display names where available. Falls back to Ref() when no display names
-// are cached.
+// are cached. Display names are resolved within the context's own session so
+// overlapping IDs across environments never borrow each other's labels.
 func (c *ConfigV1Beta1) DisplayRef(ctx *DiscoveredContext) string {
-	orgLabel := ctx.OrganizationID
-	for _, o := range c.Cache.Organizations {
-		if o.ID == ctx.OrganizationID && o.DisplayName != "" {
-			orgLabel = o.DisplayName
-			break
-		}
-	}
+	orgLabel := c.OrgDisplayName(ctx.Session, ctx.OrganizationID)
 	if ctx.ProjectID == "" {
 		return orgLabel
 	}
-	projLabel := ctx.ProjectID
-	for _, p := range c.Cache.Projects {
-		if p.ID == ctx.ProjectID && p.DisplayName != "" {
-			projLabel = p.DisplayName
-			break
-		}
-	}
-	return orgLabel + "/" + projLabel
+	return orgLabel + "/" + c.ProjectDisplayName(ctx.Session, ctx.ProjectID)
 }
 
 // ContextDescription returns a human-friendly description of the context type
@@ -111,28 +117,37 @@ func (c *ConfigV1Beta1) DisplayRef(ctx *DiscoveredContext) string {
 //	org Datum Technology, Inc (datum)
 //	project Datum Cloud in Datum Technology, Inc (datum/datum-cloud)
 func (c *ConfigV1Beta1) ContextDescription(ctx *DiscoveredContext) string {
-	orgName := c.OrgDisplayName(ctx.OrganizationID)
+	orgName := c.OrgDisplayName(ctx.Session, ctx.OrganizationID)
 	if ctx.ProjectID == "" {
 		return fmt.Sprintf("org %s (%s)", orgName, ctx.OrganizationID)
 	}
-	projName := c.ProjectDisplayName(ctx.ProjectID)
+	projName := c.ProjectDisplayName(ctx.Session, ctx.ProjectID)
 	return fmt.Sprintf("project %s in %s (%s)", projName, orgName, ctx.Ref())
 }
 
-// OrgDisplayName returns the cached display name for an org, or the ID if none.
-func (c *ConfigV1Beta1) OrgDisplayName(orgID string) string {
+// sessionMatches reports whether a cache/context entry owned by have belongs to
+// the requested session want. An empty want means "any session" — used by the
+// session-unaware lookups that predate session-scoped resolution.
+func sessionMatches(want, have string) bool {
+	return want == "" || want == have
+}
+
+// OrgDisplayName returns the cached display name for an org within the given
+// session, or the ID if none. An empty sessionName matches any session.
+func (c *ConfigV1Beta1) OrgDisplayName(sessionName, orgID string) string {
 	for _, o := range c.Cache.Organizations {
-		if o.ID == orgID && o.DisplayName != "" {
+		if o.ID == orgID && sessionMatches(sessionName, o.Session) && o.DisplayName != "" {
 			return o.DisplayName
 		}
 	}
 	return orgID
 }
 
-// ProjectDisplayName returns the cached display name for a project, or the ID if none.
-func (c *ConfigV1Beta1) ProjectDisplayName(projectID string) string {
+// ProjectDisplayName returns the cached display name for a project within the
+// given session, or the ID if none. An empty sessionName matches any session.
+func (c *ConfigV1Beta1) ProjectDisplayName(sessionName, projectID string) string {
 	for _, p := range c.Cache.Projects {
-		if p.ID == projectID && p.DisplayName != "" {
+		if p.ID == projectID && sessionMatches(sessionName, p.Session) && p.DisplayName != "" {
 			return p.DisplayName
 		}
 	}
@@ -146,17 +161,23 @@ type ContextCache struct {
 	LastRefreshed *time.Time      `json:"last-refreshed,omitempty" yaml:"last-refreshed,omitempty"`
 }
 
-// CachedOrg is an API-discovered organization.
+// CachedOrg is an API-discovered organization. Session records which login
+// discovered it, so overlapping org IDs across environments keep distinct
+// display names.
 type CachedOrg struct {
 	ID          string `json:"id" yaml:"id"`
 	DisplayName string `json:"display-name,omitempty" yaml:"display-name,omitempty"`
+	Session     string `json:"session,omitempty" yaml:"session,omitempty"`
 }
 
-// CachedProject is an API-discovered project under an org.
+// CachedProject is an API-discovered project under an org. Session records which
+// login discovered it, so overlapping project IDs across environments keep
+// distinct display names.
 type CachedProject struct {
 	ID          string `json:"id" yaml:"id"`
 	DisplayName string `json:"display-name,omitempty" yaml:"display-name,omitempty"`
 	OrgID       string `json:"org-id" yaml:"org-id"`
+	Session     string `json:"session,omitempty" yaml:"session,omitempty"`
 }
 
 func NewV1Beta1() *ConfigV1Beta1 {
@@ -216,8 +237,40 @@ func (c *ConfigV1Beta1) ContextByName(name string) *DiscoveredContext {
 	return nil
 }
 
-// ResolveContext finds a context by flexible matching. Resource IDs always
-// take precedence over display names. It tries, in order:
+// ResolveContext finds a context by flexible matching across every session. It
+// is session-unaware, so with overlapping IDs across environments the result is
+// undefined; prefer ResolveContextInSession when a session is known.
+func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
+	return c.resolveContext(query, "")
+}
+
+// ResolveContextInSession is the session-scoped analog of ResolveContext: it
+// considers only contexts owned by sessionName and resolves display names within
+// that session. This is the correct entry point once a session is known, since
+// org and project IDs (and their display names) can collide across environments.
+func (c *ConfigV1Beta1) ResolveContextInSession(query, sessionName string) *DiscoveredContext {
+	return c.resolveContext(query, sessionName)
+}
+
+// FindContextOwner returns the session that owns a context matching query in
+// some session other than excludeSession, or nil. It powers the "switch
+// sessions first" hint when a ref lives only in another environment.
+func (c *ConfigV1Beta1) FindContextOwner(query, excludeSession string) *Session {
+	for i := range c.Sessions {
+		s := &c.Sessions[i]
+		if s.Name == excludeSession {
+			continue
+		}
+		if c.ResolveContextInSession(query, s.Name) != nil {
+			return s
+		}
+	}
+	return nil
+}
+
+// resolveContext finds a context by flexible matching. Resource IDs always take
+// precedence over display names. When sessionName is non-empty, only contexts
+// and cache entries owned by that session are considered. It tries, in order:
 //
 //  1. Exact context name match
 //  2. orgID/projectID match (for "org/project" queries)
@@ -227,18 +280,27 @@ func (c *ConfigV1Beta1) ContextByName(name string) *DiscoveredContext {
 //  6. Display-name-only org or project match (unambiguous)
 //
 // Returns nil if no match, or if a display-name match is ambiguous.
-func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
-	// 1. Exact name match.
-	if ctx := c.ContextByName(query); ctx != nil {
-		return ctx
+func (c *ConfigV1Beta1) resolveContext(query, sessionName string) *DiscoveredContext {
+	// Restrict the search to the requested session (all contexts when empty).
+	var contexts []*DiscoveredContext
+	for i := range c.Contexts {
+		if sessionMatches(sessionName, c.Contexts[i].Session) {
+			contexts = append(contexts, &c.Contexts[i])
+		}
+	}
+
+	// 1. Exact name match (qualified name or, in unscoped legacy configs, ref).
+	for _, ctx := range contexts {
+		if ctx.Name == query {
+			return ctx
+		}
 	}
 
 	orgPart, projPart, hasSlash := strings.Cut(query, "/")
 
 	if hasSlash {
 		// 2. orgID/projectID match.
-		for i := range c.Contexts {
-			ctx := &c.Contexts[i]
+		for _, ctx := range contexts {
 			if ctx.OrganizationID == orgPart && ctx.ProjectID == projPart {
 				return ctx
 			}
@@ -246,7 +308,7 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 
 		// 5. Display-name match, scoped: resolve orgPart to an org ID first,
 		// then scope project display-name resolution to that org.
-		resolvedOrgIDs := c.resolveOrgIDs(orgPart)
+		resolvedOrgIDs := c.resolveOrgIDs(orgPart, sessionName)
 		if len(resolvedOrgIDs) == 0 {
 			// orgPart might already be a resource ID even though the slash path
 			// didn't match — allow it through as a search scope.
@@ -255,12 +317,11 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 
 		var match *DiscoveredContext
 		for _, orgID := range resolvedOrgIDs {
-			projIDs := c.resolveProjectIDsInOrg(projPart, orgID)
+			projIDs := c.resolveProjectIDsInOrg(projPart, orgID, sessionName)
 			// Also include projPart as a literal ID candidate within this org.
 			projIDs = appendUnique(projIDs, projPart)
 			for _, projID := range projIDs {
-				for i := range c.Contexts {
-					ctx := &c.Contexts[i]
+				for _, ctx := range contexts {
 					if ctx.OrganizationID == orgID && ctx.ProjectID == projID {
 						if match != nil && match != ctx {
 							return nil // ambiguous
@@ -274,8 +335,7 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 	}
 
 	// 3. orgID-only match (org-level contexts).
-	for i := range c.Contexts {
-		ctx := &c.Contexts[i]
+	for _, ctx := range contexts {
 		if ctx.OrganizationID == query && ctx.ProjectID == "" {
 			return ctx
 		}
@@ -283,8 +343,7 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 
 	// 4. projectID-only match if unambiguous (resource IDs only, no display names).
 	var idMatch *DiscoveredContext
-	for i := range c.Contexts {
-		ctx := &c.Contexts[i]
+	for _, ctx := range contexts {
 		if ctx.ProjectID == query {
 			if idMatch != nil {
 				return nil // ambiguous on resource ID
@@ -297,10 +356,9 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 	}
 
 	// 6a. Display-name-only org match (unambiguous).
-	resolvedOrgIDs := c.resolveOrgIDs(query)
+	resolvedOrgIDs := c.resolveOrgIDs(query, sessionName)
 	if len(resolvedOrgIDs) == 1 {
-		for i := range c.Contexts {
-			ctx := &c.Contexts[i]
+		for _, ctx := range contexts {
 			if ctx.OrganizationID == resolvedOrgIDs[0] && ctx.ProjectID == "" {
 				return ctx
 			}
@@ -310,10 +368,9 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 	}
 
 	// 6b. Display-name-only project match (unambiguous).
-	resolvedProjIDs := c.resolveProjectIDs(query)
+	resolvedProjIDs := c.resolveProjectIDs(query, sessionName)
 	if len(resolvedProjIDs) == 1 {
-		for i := range c.Contexts {
-			ctx := &c.Contexts[i]
+		for _, ctx := range contexts {
 			if ctx.ProjectID == resolvedProjIDs[0] {
 				return ctx
 			}
@@ -322,34 +379,37 @@ func (c *ConfigV1Beta1) ResolveContext(query string) *DiscoveredContext {
 	return nil
 }
 
-// resolveOrgIDs returns all org resource IDs whose display name matches.
-func (c *ConfigV1Beta1) resolveOrgIDs(displayName string) []string {
+// resolveOrgIDs returns all org resource IDs whose display name matches within
+// the given session (any session when sessionName is empty).
+func (c *ConfigV1Beta1) resolveOrgIDs(displayName, sessionName string) []string {
 	var ids []string
 	for _, o := range c.Cache.Organizations {
-		if o.DisplayName == displayName && o.DisplayName != o.ID {
+		if o.DisplayName == displayName && o.DisplayName != o.ID && sessionMatches(sessionName, o.Session) {
 			ids = append(ids, o.ID)
 		}
 	}
 	return ids
 }
 
-// resolveProjectIDs returns all project resource IDs whose display name matches.
-func (c *ConfigV1Beta1) resolveProjectIDs(displayName string) []string {
+// resolveProjectIDs returns all project resource IDs whose display name matches
+// within the given session (any session when sessionName is empty).
+func (c *ConfigV1Beta1) resolveProjectIDs(displayName, sessionName string) []string {
 	var ids []string
 	for _, p := range c.Cache.Projects {
-		if p.DisplayName == displayName && p.DisplayName != p.ID {
+		if p.DisplayName == displayName && p.DisplayName != p.ID && sessionMatches(sessionName, p.Session) {
 			ids = append(ids, p.ID)
 		}
 	}
 	return ids
 }
 
-// resolveProjectIDsInOrg returns project resource IDs whose display name
-// matches and which belong to the given org.
-func (c *ConfigV1Beta1) resolveProjectIDsInOrg(displayName, orgID string) []string {
+// resolveProjectIDsInOrg returns project resource IDs whose display name matches,
+// which belong to the given org, within the given session (any session when
+// sessionName is empty).
+func (c *ConfigV1Beta1) resolveProjectIDsInOrg(displayName, orgID, sessionName string) []string {
 	var ids []string
 	for _, p := range c.Cache.Projects {
-		if p.OrgID == orgID && p.DisplayName == displayName && p.DisplayName != p.ID {
+		if p.OrgID == orgID && p.DisplayName == displayName && p.DisplayName != p.ID && sessionMatches(sessionName, p.Session) {
 			ids = append(ids, p.ID)
 		}
 	}
@@ -371,17 +431,21 @@ func (c *ConfigV1Beta1) CurrentContextEntry() *DiscoveredContext {
 	return c.ContextByName(c.CurrentContext)
 }
 
-// ActiveSessionEntry returns the active session. It first checks ActiveSession,
-// then falls back to the session referenced by the current context.
+// ActiveSessionEntry returns the active session. The current context's session
+// is authoritative: whatever context is selected determines which environment
+// is active, so whoami and every request agree. The stored ActiveSession is
+// only a fallback for when no current context resolves (e.g. right after login
+// before a context is picked).
 func (c *ConfigV1Beta1) ActiveSessionEntry() *Session {
+	if ctx := c.CurrentContextEntry(); ctx != nil {
+		if s := c.SessionByName(ctx.Session); s != nil {
+			return s
+		}
+	}
 	if c.ActiveSession != "" {
 		if s := c.SessionByName(c.ActiveSession); s != nil {
 			return s
 		}
-	}
-	ctx := c.CurrentContextEntry()
-	if ctx != nil {
-		return c.SessionByName(ctx.Session)
 	}
 	return nil
 }
@@ -524,7 +588,55 @@ func LoadV1Beta1FromPath(path string) (*ConfigV1Beta1, error) {
 		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
 	cfg.ensureDefaults()
+	cfg.migrateSessionScoping()
 	return cfg, nil
+}
+
+// migrateSessionScoping upgrades a config written before contexts were
+// session-qualified. It rewrites bare-ref context names to the session-qualified
+// form and drops display-cache entries that predate session stamping (they
+// repopulate on the next refresh). It is idempotent and safe to run repeatedly,
+// including on partially-migrated configs, so no re-login is required.
+func (c *ConfigV1Beta1) migrateSessionScoping() {
+	for i := range c.Contexts {
+		ctx := &c.Contexts[i]
+		if ctx.Session == "" {
+			continue
+		}
+		want := ctx.QualifiedName()
+		if ctx.Name == want {
+			continue
+		}
+		old := ctx.Name
+		ctx.Name = want
+		// Repoint the pointers that addressed the old bare-ref name.
+		if c.CurrentContext == old {
+			c.CurrentContext = want
+		}
+		for j := range c.Sessions {
+			if c.Sessions[j].LastContext == old {
+				c.Sessions[j].LastContext = want
+			}
+		}
+	}
+
+	// Drop un-sessioned display-cache entries; they can no longer be attributed
+	// to an environment and repopulate on the next discovery refresh.
+	keptOrgs := c.Cache.Organizations[:0]
+	for _, o := range c.Cache.Organizations {
+		if o.Session != "" {
+			keptOrgs = append(keptOrgs, o)
+		}
+	}
+	c.Cache.Organizations = keptOrgs
+
+	keptProjects := c.Cache.Projects[:0]
+	for _, p := range c.Cache.Projects {
+		if p.Session != "" {
+			keptProjects = append(keptProjects, p)
+		}
+	}
+	c.Cache.Projects = keptProjects
 }
 
 // SaveV1Beta1 saves a v1beta1 config to the default path.

--- a/internal/datumconfig/config_v1beta1_test.go
+++ b/internal/datumconfig/config_v1beta1_test.go
@@ -13,12 +13,14 @@ func TestConfigV1Beta1RoundTrip(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config")
 
+	const sess = "jane@acme.com@api.datum.net"
+	const currentCtx = sess + "/org-acme/proj-infra"
 	original := NewV1Beta1()
-	original.CurrentContext = "org-acme/proj-infra"
-	original.ActiveSession = "jane@acme.com@api.datum.net"
+	original.CurrentContext = currentCtx
+	original.ActiveSession = sess
 	original.Sessions = []Session{
 		{
-			Name:      "jane@acme.com@api.datum.net",
+			Name:      sess,
 			UserKey:   "key-abc123",
 			UserEmail: "jane@acme.com",
 			UserName:  "Jane Doe",
@@ -26,18 +28,18 @@ func TestConfigV1Beta1RoundTrip(t *testing.T) {
 				Server:       "https://api.datum.net",
 				AuthHostname: "auth.datum.net",
 			},
-			LastContext: "org-acme/proj-infra",
+			LastContext: currentCtx,
 		},
 	}
 	original.Contexts = []DiscoveredContext{
 		{
-			Name:           "org-acme",
-			Session:        "jane@acme.com@api.datum.net",
+			Name:           sess + "/org-acme",
+			Session:        sess,
 			OrganizationID: "org-acme",
 		},
 		{
-			Name:           "org-acme/proj-infra",
-			Session:        "jane@acme.com@api.datum.net",
+			Name:           currentCtx,
+			Session:        sess,
 			OrganizationID: "org-acme",
 			ProjectID:      "proj-infra",
 			Namespace:      "default",
@@ -59,18 +61,18 @@ func TestConfigV1Beta1RoundTrip(t *testing.T) {
 	if loaded.Kind != DefaultKind {
 		t.Errorf("Kind=%q, want %q", loaded.Kind, DefaultKind)
 	}
-	if loaded.CurrentContext != "org-acme/proj-infra" {
-		t.Errorf("CurrentContext=%q, want %q", loaded.CurrentContext, "org-acme/proj-infra")
+	if loaded.CurrentContext != currentCtx {
+		t.Errorf("CurrentContext=%q, want %q", loaded.CurrentContext, currentCtx)
 	}
-	if loaded.ActiveSession != "jane@acme.com@api.datum.net" {
-		t.Errorf("ActiveSession=%q, want %q", loaded.ActiveSession, "jane@acme.com@api.datum.net")
+	if loaded.ActiveSession != sess {
+		t.Errorf("ActiveSession=%q, want %q", loaded.ActiveSession, sess)
 	}
 	if len(loaded.Sessions) != 1 {
 		t.Fatalf("Sessions len=%d, want 1", len(loaded.Sessions))
 	}
 	s := loaded.Sessions[0]
-	if s.Name != "jane@acme.com@api.datum.net" {
-		t.Errorf("Session.Name=%q, want %q", s.Name, "jane@acme.com@api.datum.net")
+	if s.Name != sess {
+		t.Errorf("Session.Name=%q, want %q", s.Name, sess)
 	}
 	if s.UserKey != "key-abc123" {
 		t.Errorf("Session.UserKey=%q, want %q", s.UserKey, "key-abc123")
@@ -84,8 +86,8 @@ func TestConfigV1Beta1RoundTrip(t *testing.T) {
 	if s.Endpoint.Server != "https://api.datum.net" {
 		t.Errorf("Endpoint.Server=%q, want %q", s.Endpoint.Server, "https://api.datum.net")
 	}
-	if s.LastContext != "org-acme/proj-infra" {
-		t.Errorf("Session.LastContext=%q, want %q", s.LastContext, "org-acme/proj-infra")
+	if s.LastContext != currentCtx {
+		t.Errorf("Session.LastContext=%q, want %q", s.LastContext, currentCtx)
 	}
 	if len(loaded.Contexts) != 2 {
 		t.Fatalf("Contexts len=%d, want 2", len(loaded.Contexts))
@@ -310,8 +312,9 @@ func TestHasMultipleEndpoints(t *testing.T) {
 	}
 }
 
-// TestActiveSessionEntry verifies fallback logic: explicit ActiveSession first,
-// then session derived from current context.
+// TestActiveSessionEntry verifies the single-source-of-truth precedence: the
+// current context's session is authoritative, and the stored ActiveSession is
+// only a fallback for when no current context resolves.
 func TestActiveSessionEntry(t *testing.T) {
 	t.Parallel()
 
@@ -321,7 +324,7 @@ func TestActiveSessionEntry(t *testing.T) {
 		{Name: "sess-2", UserEmail: "bob@example.com"},
 	}
 	cfg.Contexts = []DiscoveredContext{
-		{Name: "acme-corp", Session: "sess-1"},
+		{Name: "sess-1/acme-corp", Session: "sess-1", OrganizationID: "acme-corp"},
 	}
 
 	// No active session and no current context — should return nil.
@@ -330,34 +333,37 @@ func TestActiveSessionEntry(t *testing.T) {
 		t.Errorf("expected nil when no ActiveSession and no CurrentContext, got %+v", got)
 	}
 
-	// Set CurrentContext only — should fall back to context's session.
-	cfg.CurrentContext = "acme-corp"
+	// ActiveSession only (no current context) — falls back to ActiveSession.
+	cfg.ActiveSession = "sess-2"
+	got = cfg.ActiveSessionEntry()
+	if got == nil {
+		t.Fatal("expected fallback to ActiveSession, got nil")
+	}
+	if got.UserEmail != "bob@example.com" {
+		t.Errorf("fallback UserEmail=%q, want %q", got.UserEmail, "bob@example.com")
+	}
+
+	// Set a current context — its session wins over a divergent ActiveSession.
+	// This is the #248 fix: whoami must not report a different environment than
+	// the one the current context routes requests to.
+	cfg.CurrentContext = "sess-1/acme-corp"
 	got = cfg.ActiveSessionEntry()
 	if got == nil {
 		t.Fatal("expected session from current context, got nil")
 	}
 	if got.UserEmail != "alice@example.com" {
-		t.Errorf("UserEmail=%q, want %q", got.UserEmail, "alice@example.com")
+		t.Errorf("current context's session must win: UserEmail=%q, want %q", got.UserEmail, "alice@example.com")
 	}
 
-	// Set explicit ActiveSession — should prefer it over context session.
-	cfg.ActiveSession = "sess-2"
+	// Current context points at a missing session — fall back to ActiveSession.
+	cfg.CurrentContext = "sess-1/gone"
+	cfg.Contexts = append(cfg.Contexts, DiscoveredContext{Name: "sess-1/gone", Session: "removed-session"})
 	got = cfg.ActiveSessionEntry()
 	if got == nil {
-		t.Fatal("expected session from ActiveSession, got nil")
+		t.Fatal("expected fallback to ActiveSession when context session missing, got nil")
 	}
 	if got.UserEmail != "bob@example.com" {
-		t.Errorf("UserEmail=%q, want %q", got.UserEmail, "bob@example.com")
-	}
-
-	// ActiveSession set but nonexistent — falls back to current context.
-	cfg.ActiveSession = "nonexistent"
-	got = cfg.ActiveSessionEntry()
-	if got == nil {
-		t.Fatal("expected fallback to current context session, got nil")
-	}
-	if got.UserEmail != "alice@example.com" {
-		t.Errorf("fallback UserEmail=%q, want %q", got.UserEmail, "alice@example.com")
+		t.Errorf("fallback UserEmail=%q, want %q", got.UserEmail, "bob@example.com")
 	}
 }
 
@@ -772,5 +778,230 @@ func TestDisplayRef(t *testing.T) {
 	orphan := &DiscoveredContext{OrganizationID: "unknown-org", ProjectID: "unknown-proj"}
 	if got := cfg.DisplayRef(orphan); got != "unknown-org/unknown-proj" {
 		t.Errorf("orphan DisplayRef = %q, want IDs", got)
+	}
+}
+
+// TestActiveSessionEntry_Issue248 reproduces the production incident: a user is
+// logged into staging (ActiveSession = staging) but has selected a production
+// context. whoami reads ActiveSessionEntry, and it must report production —
+// the same environment requests route to — not the stale ActiveSession.
+func TestActiveSessionEntry_Issue248(t *testing.T) {
+	t.Parallel()
+
+	const staging = "user@example.com@api.staging.datum.net"
+	const prod = "user@example.com@api.datum.net"
+
+	cfg := NewV1Beta1()
+	cfg.Sessions = []Session{
+		{Name: staging, UserEmail: "user@example.com", Endpoint: Endpoint{Server: "https://api.staging.datum.net"}},
+		{Name: prod, UserEmail: "user@example.com", Endpoint: Endpoint{Server: "https://api.datum.net"}},
+	}
+	cfg.Contexts = []DiscoveredContext{
+		{Name: QualifiedContextName(prod, "datum/datum-cloud"), Session: prod, OrganizationID: "datum", ProjectID: "datum-cloud"},
+	}
+	// The bug state: ActiveSession still names staging, but the current context
+	// belongs to prod (as it would after `ctx use` a prod context).
+	cfg.ActiveSession = staging
+	cfg.CurrentContext = QualifiedContextName(prod, "datum/datum-cloud")
+
+	got := cfg.ActiveSessionEntry()
+	if got == nil {
+		t.Fatal("ActiveSessionEntry returned nil")
+	}
+	if got.Name != prod {
+		t.Errorf("ActiveSessionEntry = %q, want %q (must follow the current context, not the stale ActiveSession)", got.Name, prod)
+	}
+}
+
+// TestActiveSessionEntry_FallbackWhenNoContext verifies a freshly-logged-in
+// session with no current context falls back to ActiveSession.
+func TestActiveSessionEntry_FallbackWhenNoContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewV1Beta1()
+	cfg.Sessions = []Session{{Name: "fresh@api.datum.net", UserEmail: "fresh@example.com"}}
+	cfg.ActiveSession = "fresh@api.datum.net"
+	// No CurrentContext set (as right after login before picking one).
+
+	got := cfg.ActiveSessionEntry()
+	if got == nil {
+		t.Fatal("expected fallback to ActiveSession, got nil")
+	}
+	if got.UserEmail != "fresh@example.com" {
+		t.Errorf("UserEmail=%q, want %q", got.UserEmail, "fresh@example.com")
+	}
+}
+
+// TestResolveContextInSession_ScopedAddressing verifies that a ref is resolved
+// only within the active session, and that a ref living solely in another
+// session is not silently borrowed — instead FindContextOwner names the owner.
+func TestResolveContextInSession_ScopedAddressing(t *testing.T) {
+	t.Parallel()
+
+	const staging = "user@example.com@api.staging.datum.net"
+	const prod = "user@example.com@api.datum.net"
+
+	cfg := NewV1Beta1()
+	cfg.Sessions = []Session{
+		{Name: staging, UserEmail: "user@example.com", Endpoint: Endpoint{Server: "https://api.staging.datum.net"}},
+		{Name: prod, UserEmail: "user@example.com", Endpoint: Endpoint{Server: "https://api.datum.net"}},
+	}
+	cfg.Contexts = []DiscoveredContext{
+		// Both environments share the identical ref.
+		{Name: QualifiedContextName(staging, "datum/datum-cloud"), Session: staging, OrganizationID: "datum", ProjectID: "datum-cloud"},
+		{Name: QualifiedContextName(prod, "datum/datum-cloud"), Session: prod, OrganizationID: "datum", ProjectID: "datum-cloud"},
+		// A ref that exists only in prod.
+		{Name: QualifiedContextName(prod, "datum/prod-only"), Session: prod, OrganizationID: "datum", ProjectID: "prod-only"},
+	}
+
+	// Shared ref resolves within the active (staging) session to staging's entry.
+	got := cfg.ResolveContextInSession("datum/datum-cloud", staging)
+	if got == nil || got.Session != staging {
+		t.Fatalf("ResolveContextInSession(shared, staging) = %+v, want staging entry", got)
+	}
+
+	// A prod-only ref is NOT resolvable while staging is active.
+	if got := cfg.ResolveContextInSession("datum/prod-only", staging); got != nil {
+		t.Errorf("ResolveContextInSession(prod-only, staging) = %+v, want nil", got)
+	}
+
+	// FindContextOwner points at the prod session so the command can tell the
+	// user to switch first.
+	owner := cfg.FindContextOwner("datum/prod-only", staging)
+	if owner == nil {
+		t.Fatal("FindContextOwner(prod-only, staging) = nil, want prod session")
+	}
+	if owner.Name != prod {
+		t.Errorf("owner = %q, want %q", owner.Name, prod)
+	}
+
+	// A ref that exists nowhere has no owner.
+	if owner := cfg.FindContextOwner("datum/nope", staging); owner != nil {
+		t.Errorf("FindContextOwner(nope) = %+v, want nil", owner)
+	}
+}
+
+// TestResolveContextInSession_DisplayNamesScopedToSession verifies that display
+// names collide across environments but resolve within the correct session.
+func TestResolveContextInSession_DisplayNamesScopedToSession(t *testing.T) {
+	t.Parallel()
+
+	const staging = "s@api.staging.datum.net"
+	const prod = "s@api.datum.net"
+
+	cfg := NewV1Beta1()
+	// Same org ID "datum" in both, but different display names per environment.
+	cfg.Cache.Organizations = []CachedOrg{
+		{ID: "datum", DisplayName: "Datum Staging", Session: staging},
+		{ID: "datum", DisplayName: "Datum Production", Session: prod},
+	}
+	cfg.Contexts = []DiscoveredContext{
+		{Name: QualifiedContextName(staging, "datum"), Session: staging, OrganizationID: "datum"},
+		{Name: QualifiedContextName(prod, "datum"), Session: prod, OrganizationID: "datum"},
+	}
+
+	if got := cfg.OrgDisplayName(staging, "datum"); got != "Datum Staging" {
+		t.Errorf("OrgDisplayName(staging) = %q, want %q", got, "Datum Staging")
+	}
+	if got := cfg.OrgDisplayName(prod, "datum"); got != "Datum Production" {
+		t.Errorf("OrgDisplayName(prod) = %q, want %q", got, "Datum Production")
+	}
+
+	// Resolving the production display name while staging is active must fail —
+	// it belongs to a different environment.
+	if got := cfg.ResolveContextInSession("Datum Production", staging); got != nil {
+		t.Errorf("ResolveContextInSession(Datum Production, staging) = %+v, want nil", got)
+	}
+	if got := cfg.ResolveContextInSession("Datum Production", prod); got == nil || got.Session != prod {
+		t.Errorf("ResolveContextInSession(Datum Production, prod) = %+v, want prod entry", got)
+	}
+}
+
+// TestMigrateSessionScoping verifies that a config written before session
+// qualification is upgraded on load: context names become session-qualified,
+// the current-context and last-context pointers follow, contexts stay intact,
+// and un-sessioned display-cache entries are dropped.
+func TestMigrateSessionScoping(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config")
+
+	// A pre-change config: bare-ref context names, un-sessioned cache.
+	legacy := `apiVersion: datumctl.config.datum.net/v1beta1
+kind: DatumctlConfig
+current-context: datum/datum-cloud
+active-session: user@example.com@api.datum.net
+sessions:
+- name: user@example.com@api.datum.net
+  user-key: k1
+  user-email: user@example.com
+  endpoint:
+    server: https://api.datum.net
+    auth-hostname: auth.datum.net
+  last-context: datum/datum-cloud
+contexts:
+- name: datum
+  session: user@example.com@api.datum.net
+  organization-id: datum
+- name: datum/datum-cloud
+  session: user@example.com@api.datum.net
+  organization-id: datum
+  project-id: datum-cloud
+  namespace: default
+cache:
+  organizations:
+  - id: datum
+    display-name: Datum Technology
+  projects:
+  - id: datum-cloud
+    display-name: Datum Cloud
+    org-id: datum
+`
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cfg, err := LoadV1Beta1FromPath(path)
+	if err != nil {
+		t.Fatalf("LoadV1Beta1FromPath: %v", err)
+	}
+
+	const sess = "user@example.com@api.datum.net"
+	wantCurrent := QualifiedContextName(sess, "datum/datum-cloud")
+
+	// Names upgraded to the qualified form.
+	if cfg.CurrentContext != wantCurrent {
+		t.Errorf("CurrentContext=%q, want %q", cfg.CurrentContext, wantCurrent)
+	}
+	if got := cfg.SessionByName(sess); got == nil || got.LastContext != wantCurrent {
+		t.Errorf("LastContext not migrated: %+v", got)
+	}
+	// Contexts intact and addressable by their new qualified names.
+	if len(cfg.Contexts) != 2 {
+		t.Fatalf("Contexts len=%d, want 2", len(cfg.Contexts))
+	}
+	if cfg.ContextByName(wantCurrent) == nil {
+		t.Error("qualified project context not found after migration")
+	}
+	if cfg.CurrentContextEntry() == nil {
+		t.Error("current context does not resolve after migration")
+	}
+	// Un-sessioned cache dropped.
+	if len(cfg.Cache.Organizations) != 0 || len(cfg.Cache.Projects) != 0 {
+		t.Errorf("un-sessioned cache not dropped: orgs=%d projects=%d",
+			len(cfg.Cache.Organizations), len(cfg.Cache.Projects))
+	}
+
+	// Migration is idempotent: running it again changes nothing.
+	before := cfg.CurrentContext
+	cfg.migrateSessionScoping()
+	if cfg.CurrentContext != before {
+		t.Errorf("migration not idempotent: CurrentContext changed to %q", cfg.CurrentContext)
+	}
+	for i := range cfg.Contexts {
+		if cfg.Contexts[i].Name != cfg.Contexts[i].QualifiedName() {
+			t.Errorf("context %d not stable under re-migration: %q", i, cfg.Contexts[i].Name)
+		}
 	}
 }

--- a/internal/discovery/cache.go
+++ b/internal/discovery/cache.go
@@ -27,15 +27,18 @@ func UpdateConfigCache(
 	now := time.Now().UTC()
 	cfg.Cache.LastRefreshed = &now
 
-	MergeCacheFromDiscovery(cfg, orgs, projects)
+	MergeCacheFromDiscovery(cfg, sessionName, orgs, projects)
 	SyncContextsForSession(cfg, sessionName, orgs, projects)
 	GCCache(cfg)
 }
 
 // MergeCacheFromDiscovery updates the cache with newly discovered orgs and
-// projects. Existing entries are updated; unmentioned entries are preserved.
+// projects for the given session. Existing entries for that session are
+// updated; entries from other sessions are preserved. Stamping each entry with
+// its session keeps overlapping IDs across environments from colliding.
 func MergeCacheFromDiscovery(
 	cfg *datumconfig.ConfigV1Beta1,
+	sessionName string,
 	orgs []DiscoveredOrg,
 	projects []DiscoveredProject,
 ) {
@@ -43,6 +46,7 @@ func MergeCacheFromDiscovery(
 		upsertCachedOrg(&cfg.Cache, datumconfig.CachedOrg{
 			ID:          o.Name,
 			DisplayName: o.DisplayName,
+			Session:     sessionName,
 		})
 	}
 	for _, p := range projects {
@@ -50,6 +54,7 @@ func MergeCacheFromDiscovery(
 			ID:          p.Name,
 			DisplayName: p.DisplayName,
 			OrgID:       p.OrgName,
+			Session:     sessionName,
 		})
 	}
 }
@@ -72,42 +77,46 @@ func SyncContextsForSession(
 	cfg.Contexts = remaining
 
 	for _, o := range orgs {
-		cfg.UpsertContext(datumconfig.DiscoveredContext{
-			Name:           o.Name,
+		ctx := datumconfig.DiscoveredContext{
 			Session:        sessionName,
 			OrganizationID: o.Name,
-		})
+		}
+		ctx.Name = ctx.QualifiedName()
+		cfg.UpsertContext(ctx)
 	}
 
 	for _, p := range projects {
-		cfg.UpsertContext(datumconfig.DiscoveredContext{
-			Name:           fmt.Sprintf("%s/%s", p.OrgName, p.Name),
+		ctx := datumconfig.DiscoveredContext{
 			Session:        sessionName,
 			OrganizationID: p.OrgName,
 			ProjectID:      p.Name,
 			Namespace:      datumconfig.DefaultNamespace,
-		})
+		}
+		ctx.Name = ctx.QualifiedName()
+		cfg.UpsertContext(ctx)
 	}
 }
 
 // GCCache removes cached orgs and projects that are no longer referenced by
-// any DiscoveredContext in the config. This is safe to call at any time and
-// correctly preserves entries referenced by other sessions' contexts.
+// any DiscoveredContext in the config. Reference is matched on (session, id) so
+// that overlapping IDs across environments are garbage-collected independently
+// and one session's refresh never evicts another session's cache.
 func GCCache(cfg *datumconfig.ConfigV1Beta1) {
-	referencedOrgs := make(map[string]bool)
-	referencedProjects := make(map[string]bool)
+	type ref struct{ session, id string }
+	referencedOrgs := make(map[ref]bool)
+	referencedProjects := make(map[ref]bool)
 	for _, ctx := range cfg.Contexts {
 		if ctx.OrganizationID != "" {
-			referencedOrgs[ctx.OrganizationID] = true
+			referencedOrgs[ref{ctx.Session, ctx.OrganizationID}] = true
 		}
 		if ctx.ProjectID != "" {
-			referencedProjects[ctx.ProjectID] = true
+			referencedProjects[ref{ctx.Session, ctx.ProjectID}] = true
 		}
 	}
 
 	keptOrgs := make([]datumconfig.CachedOrg, 0, len(cfg.Cache.Organizations))
 	for _, o := range cfg.Cache.Organizations {
-		if referencedOrgs[o.ID] {
+		if referencedOrgs[ref{o.Session, o.ID}] {
 			keptOrgs = append(keptOrgs, o)
 		}
 	}
@@ -115,7 +124,7 @@ func GCCache(cfg *datumconfig.ConfigV1Beta1) {
 
 	keptProjects := make([]datumconfig.CachedProject, 0, len(cfg.Cache.Projects))
 	for _, p := range cfg.Cache.Projects {
-		if referencedProjects[p.ID] {
+		if referencedProjects[ref{p.Session, p.ID}] {
 			keptProjects = append(keptProjects, p)
 		}
 	}
@@ -159,7 +168,7 @@ func IsCacheStale(cfg *datumconfig.ConfigV1Beta1, maxAge time.Duration) bool {
 
 func upsertCachedOrg(cache *datumconfig.ContextCache, org datumconfig.CachedOrg) {
 	for i := range cache.Organizations {
-		if cache.Organizations[i].ID == org.ID {
+		if cache.Organizations[i].ID == org.ID && cache.Organizations[i].Session == org.Session {
 			cache.Organizations[i] = org
 			return
 		}
@@ -169,7 +178,7 @@ func upsertCachedOrg(cache *datumconfig.ContextCache, org datumconfig.CachedOrg)
 
 func upsertCachedProject(cache *datumconfig.ContextCache, proj datumconfig.CachedProject) {
 	for i := range cache.Projects {
-		if cache.Projects[i].ID == proj.ID {
+		if cache.Projects[i].ID == proj.ID && cache.Projects[i].Session == proj.Session {
 			cache.Projects[i] = proj
 			return
 		}

--- a/internal/discovery/cache_test.go
+++ b/internal/discovery/cache_test.go
@@ -34,7 +34,7 @@ func TestUpdateConfigCache_GeneratesOrgAndProjectContexts(t *testing.T) {
 	}
 
 	// Verify org context uses resource name.
-	ctx := cfg.ContextByName("org-acme")
+	ctx := cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-acme"))
 	if ctx == nil {
 		t.Fatal("expected org context 'org-acme', not found")
 	}
@@ -49,7 +49,7 @@ func TestUpdateConfigCache_GeneratesOrgAndProjectContexts(t *testing.T) {
 	}
 
 	// Verify project context uses "orgID/projectID" format.
-	projCtx := cfg.ContextByName("org-acme/proj-infra")
+	projCtx := cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-acme/proj-infra"))
 	if projCtx == nil {
 		t.Fatal("expected project context 'org-acme/proj-infra', not found")
 	}
@@ -64,7 +64,7 @@ func TestUpdateConfigCache_GeneratesOrgAndProjectContexts(t *testing.T) {
 	}
 
 	// Check cross-org project.
-	sandboxCtx := cfg.ContextByName("org-personal/proj-sandbox")
+	sandboxCtx := cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-personal/proj-sandbox"))
 	if sandboxCtx == nil {
 		t.Error("expected project context 'org-personal/proj-sandbox', not found")
 	}
@@ -87,12 +87,12 @@ func TestUpdateConfigCache_FallsBackToIDWhenNoDisplayName(t *testing.T) {
 
 	UpdateConfigCache(cfg, sessionName, orgs, projects)
 
-	orgCtx := cfg.ContextByName("org-123")
+	orgCtx := cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-123"))
 	if orgCtx == nil {
 		t.Error("expected org context 'org-123', not found")
 	}
 
-	projCtx := cfg.ContextByName("org-123/proj-456")
+	projCtx := cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-123/proj-456"))
 	if projCtx == nil {
 		t.Error("expected project context 'org-123/proj-456', not found")
 	}
@@ -130,7 +130,7 @@ func TestUpdateConfigCache_ReplacesExistingSessionContexts(t *testing.T) {
 	}
 
 	// New context uses resource name, not display name.
-	if cfg.ContextByName("org-new") == nil {
+	if cfg.ContextByName(datumconfig.QualifiedContextName(sessionName, "org-new")) == nil {
 		t.Error("new org context 'org-new' should be present")
 	}
 }
@@ -223,10 +223,10 @@ func TestUpdateConfigCache_MultiSession_PreservesOtherSessionCache(t *testing.T)
 	})
 
 	// Sanity: both sessions' data is present.
-	if cfg.OrgDisplayName("org-prod") != "Production" {
+	if cfg.OrgDisplayName(session1, "org-prod") != "Production" {
 		t.Fatal("setup: Production cache missing")
 	}
-	if cfg.OrgDisplayName("org-stg") != "Staging" {
+	if cfg.OrgDisplayName(session2, "org-stg") != "Staging" {
 		t.Fatal("setup: Staging cache missing")
 	}
 
@@ -237,10 +237,10 @@ func TestUpdateConfigCache_MultiSession_PreservesOtherSessionCache(t *testing.T)
 		{Name: "proj-p1", DisplayName: "Production Project", OrgName: "org-prod"},
 	})
 
-	if cfg.OrgDisplayName("org-stg") != "Staging" {
+	if cfg.OrgDisplayName(session2, "org-stg") != "Staging" {
 		t.Error("session2's org cache was wiped by session1 refresh")
 	}
-	if cfg.ProjectDisplayName("proj-s1") != "Staging Project" {
+	if cfg.ProjectDisplayName(session2, "proj-s1") != "Staging Project" {
 		t.Error("session2's project cache was wiped by session1 refresh")
 	}
 }
@@ -266,7 +266,7 @@ func TestGCCache_RemovesUnreferencedEntries(t *testing.T) {
 
 	GCCache(cfg)
 
-	if cfg.OrgDisplayName("org-kept") != "Kept" {
+	if cfg.OrgDisplayName("", "org-kept") != "Kept" {
 		t.Error("referenced org was removed")
 	}
 	if len(cfg.Cache.Organizations) != 1 {
@@ -309,25 +309,93 @@ func TestMergeCacheFromDiscovery(t *testing.T) {
 	t.Parallel()
 
 	cfg := datumconfig.NewV1Beta1()
+	sessionName := "user@api.datum.net"
 	cfg.Cache.Organizations = []datumconfig.CachedOrg{
-		{ID: "org-existing", DisplayName: "Old Name"},
+		{ID: "org-existing", DisplayName: "Old Name", Session: sessionName},
 	}
 
-	MergeCacheFromDiscovery(cfg, []DiscoveredOrg{
+	MergeCacheFromDiscovery(cfg, sessionName, []DiscoveredOrg{
 		{Name: "org-existing", DisplayName: "New Name"},
 		{Name: "org-new", DisplayName: "New Org"},
 	}, nil)
 
-	// Existing was updated.
-	if cfg.OrgDisplayName("org-existing") != "New Name" {
-		t.Errorf("existing org not updated, got %q", cfg.OrgDisplayName("org-existing"))
+	// Existing was updated in place (not duplicated).
+	if cfg.OrgDisplayName(sessionName, "org-existing") != "New Name" {
+		t.Errorf("existing org not updated, got %q", cfg.OrgDisplayName(sessionName, "org-existing"))
+	}
+	if len(cfg.Cache.Organizations) != 2 {
+		t.Errorf("Cache.Organizations len=%d, want 2 (updated existing + one new)", len(cfg.Cache.Organizations))
 	}
 	// New was added.
-	if cfg.OrgDisplayName("org-new") != "New Org" {
+	if cfg.OrgDisplayName(sessionName, "org-new") != "New Org" {
 		t.Errorf("new org not added")
 	}
 	// No contexts should have been created.
 	if len(cfg.Contexts) != 0 {
 		t.Errorf("merge should not touch contexts, got %d", len(cfg.Contexts))
+	}
+}
+
+// TestUpdateConfigCache_OverlappingIDsIsolatedBySession verifies the core fix:
+// two sessions expose the identical ref "datum/datum-cloud" with different
+// display names. Refreshing each in turn must leave both contexts intact with
+// the correct owning session, and neither session's display names may leak into
+// the other.
+func TestUpdateConfigCache_OverlappingIDsIsolatedBySession(t *testing.T) {
+	t.Parallel()
+
+	cfg := datumconfig.NewV1Beta1()
+	const staging = "user@example.com@api.staging.datum.net"
+	const prod = "user@example.com@api.datum.net"
+
+	stagingOrgs := []DiscoveredOrg{{Name: "datum", DisplayName: "Datum Staging"}}
+	stagingProjects := []DiscoveredProject{{Name: "datum-cloud", DisplayName: "Datum Cloud (staging)", OrgName: "datum"}}
+	prodOrgs := []DiscoveredOrg{{Name: "datum", DisplayName: "Datum Production"}}
+	prodProjects := []DiscoveredProject{{Name: "datum-cloud", DisplayName: "Datum Cloud (prod)", OrgName: "datum"}}
+
+	// Discover both environments.
+	UpdateConfigCache(cfg, staging, stagingOrgs, stagingProjects)
+	UpdateConfigCache(cfg, prod, prodOrgs, prodProjects)
+
+	assertBothIntact := func(stage string) {
+		t.Helper()
+		// Both sessions keep their own context for the overlapping ref.
+		stgCtx := cfg.ContextByName(datumconfig.QualifiedContextName(staging, "datum/datum-cloud"))
+		if stgCtx == nil || stgCtx.Session != staging {
+			t.Fatalf("%s: staging context missing or mis-owned: %+v", stage, stgCtx)
+		}
+		prodCtx := cfg.ContextByName(datumconfig.QualifiedContextName(prod, "datum/datum-cloud"))
+		if prodCtx == nil || prodCtx.Session != prod {
+			t.Fatalf("%s: prod context missing or mis-owned: %+v", stage, prodCtx)
+		}
+		// Display names stay pinned to their own environment.
+		if got := cfg.ProjectDisplayName(staging, "datum-cloud"); got != "Datum Cloud (staging)" {
+			t.Errorf("%s: staging project display = %q, want staging label", stage, got)
+		}
+		if got := cfg.ProjectDisplayName(prod, "datum-cloud"); got != "Datum Cloud (prod)" {
+			t.Errorf("%s: prod project display = %q, want prod label", stage, got)
+		}
+		if got := cfg.OrgDisplayName(staging, "datum"); got != "Datum Staging" {
+			t.Errorf("%s: staging org display = %q", stage, got)
+		}
+		if got := cfg.OrgDisplayName(prod, "datum"); got != "Datum Production" {
+			t.Errorf("%s: prod org display = %q", stage, got)
+		}
+	}
+
+	assertBothIntact("after initial discovery")
+
+	// Re-refresh staging — the prod context and its labels must survive untouched.
+	UpdateConfigCache(cfg, staging, stagingOrgs, stagingProjects)
+	assertBothIntact("after staging refresh")
+
+	// Re-refresh prod — likewise for staging.
+	UpdateConfigCache(cfg, prod, prodOrgs, prodProjects)
+	assertBothIntact("after prod refresh")
+
+	// Four contexts total — one org + one project per session — with no
+	// cross-write duplicating or clobbering entries.
+	if len(cfg.Contexts) != 4 {
+		t.Errorf("Contexts len=%d, want 4 (org + project per session)", len(cfg.Contexts))
 	}
 }

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -103,7 +103,7 @@ func buildContextOptions(contexts []datumconfig.DiscoveredContext, cfg *datumcon
 
 		// Org entry — show display name with resource name when they differ.
 		if g.orgCtx != nil {
-			label := datumconfig.FormatWithID(cfg.OrgDisplayName(orgID), orgID)
+			label := datumconfig.FormatWithID(cfg.OrgDisplayName(g.orgCtx.Session, orgID), orgID)
 			if cfg.CurrentContext == g.orgCtx.Name {
 				label += "  *"
 			}
@@ -112,7 +112,7 @@ func buildContextOptions(contexts []datumconfig.DiscoveredContext, cfg *datumcon
 
 		// Project entries, indented under their org.
 		for _, p := range g.projects {
-			label := "  " + datumconfig.FormatWithID(cfg.ProjectDisplayName(p.ProjectID), p.ProjectID)
+			label := "  " + datumconfig.FormatWithID(cfg.ProjectDisplayName(p.Session, p.ProjectID), p.ProjectID)
 			if cfg.CurrentContext == p.Name {
 				label += "  *"
 			}


### PR DESCRIPTION
## The problem

When you're logged into more than one Datum Cloud environment at once — say staging and production — a couple of things could quietly go wrong.

**whoami reported the wrong environment.** After switching to a production context while an earlier staging login was still around, `datumctl whoami` would print staging even though every actual request was going to production. The identity the CLI showed you and the environment it talked to had drifted apart. This caused a production incident: operators believed they were pointed at one environment while acting on another.

**Overlapping names corrupted your setup.** Organization and project names aren't globally unique — staging and production can both have an org `datum` and a project `datum-cloud`. Because contexts were tracked by that bare name alone, refreshing one environment could silently reassign the other environment's context to it, and one environment could render the other's display names. Addressing a context by name across environments was undefined.

## The fix

The environment you're working in is now always the one your selected context belongs to — whoami, requests, and the landing screen all agree, with the previously-active login used only as a fallback before you've picked a context. Switching accounts or contexts keeps that in lockstep.

Contexts are now tracked per login, so an org or project that exists in two environments no longer overwrites its twin, and its display name stays pinned to the environment it came from. You address contexts relative to the environment you're signed into; ask for one that only exists in another and the CLI tells you which account to switch to first instead of guessing.

`datumctl ctx` (and `ctx list`) now show just the active environment by default. Use `--all` to see every environment's contexts grouped by account and endpoint, so overlapping names are easy to tell apart.

Existing logins upgrade in place the next time the config loads — no need to sign in again.

Fixes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)