### PR TITLE
fix: honor ^C during interactive login waits

### DIFF
--- a/internal/authutil/login_test.go
+++ b/internal/authutil/login_test.go
@@ -1,0 +1,55 @@
+package authutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestPollDeviceToken_ContextCancel verifies that a canceled context aborts the
+// device-code poll promptly with context.Canceled. This is the cancellation
+// path that #252 makes reachable: before that fix the login flow ran with a
+// non-cancellable context.Background(), so ^C/^D could never interrupt the
+// wait. The token server here always answers "authorization_pending", so the
+// only way the poll returns is via context cancellation.
+func TestPollDeviceToken_ContextCancel(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the poll starts, while it is sleeping between
+	// attempts (interval is 1s below).
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	// intervalSeconds=1 keeps the between-attempt sleep long enough that the
+	// select lands on ctx.Done() rather than the timer.
+	token, err := pollDeviceToken(ctx, srv.URL, "client-id", "device-code", 1, 0)
+	elapsed := time.Since(start)
+
+	if token != nil {
+		t.Fatalf("expected nil token on cancellation, got %#v", token)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed > 900*time.Millisecond {
+		t.Fatalf("poll did not abort promptly on cancel: took %s", elapsed)
+	}
+	if atomic.LoadInt32(&calls) == 0 {
+		t.Fatal("expected at least one poll attempt before cancel")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,16 +50,27 @@ func main() {
 	})
 
 	if err := cli.RunNoErrOutput(rootCmd); err != nil {
-		// A canceled context means the user interrupted (^C / SIGTERM).
-		// Exit quietly with the conventional 128+SIGINT code instead of
-		// printing a spurious "context canceled" error.
-		if errors.Is(err, context.Canceled) {
+		code, interrupted := exitCodeForError(err)
+		if interrupted {
+			// The user interrupted (^C / SIGTERM). Exit quietly instead of
+			// printing a spurious "context canceled" error.
 			fmt.Fprintln(os.Stderr, "\nAborted.")
-			os.Exit(130)
+		} else {
+			customerrors.Format(os.Stderr, err, formatFor(rootCmd), verbosity())
 		}
-		customerrors.Format(os.Stderr, err, formatFor(rootCmd), verbosity())
-		os.Exit(activation.ExitCodeOf(err))
+		os.Exit(code)
 	}
+}
+
+// exitCodeForError maps a command error to a process exit code. interrupted is
+// true when the error was a user interrupt (^C / SIGTERM), which surfaces as a
+// canceled context and should be reported quietly with the conventional
+// 128+SIGINT exit code rather than as an error.
+func exitCodeForError(err error) (code int, interrupted bool) {
+	if errors.Is(err, context.Canceled) {
+		return 130, true
+	}
+	return activation.ExitCodeOf(err), false
 }
 
 // formatFor reads --error-format off the parsed root command, falling back to

--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"go.datum.net/datumctl/internal/cmd"
@@ -20,6 +23,14 @@ import (
 func main() {
 	logs.GlogSetter(kubectlcmd.GetLogVerbosity(os.Args))
 	rootCmd := cmd.RootCmd()
+
+	// Wire SIGINT/SIGTERM to a cancellable context so long interactive waits
+	// (e.g. the login callback/device-code polling) can be interrupted with
+	// ^C. cli.RunNoErrOutput calls cmd.Execute(), and Cobra honors a context
+	// set via SetContext, so the signal-derived context reaches cmd.Context().
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	rootCmd.SetContext(ctx)
 
 	// Route kubectl's internal fatal errors (from util.CheckErr) through the
 	// same Format helper so --error-format applies uniformly. In human mode
@@ -39,6 +50,13 @@ func main() {
 	})
 
 	if err := cli.RunNoErrOutput(rootCmd); err != nil {
+		// A canceled context means the user interrupted (^C / SIGTERM).
+		// Exit quietly with the conventional 128+SIGINT code instead of
+		// printing a spurious "context canceled" error.
+		if errors.Is(err, context.Canceled) {
+			fmt.Fprintln(os.Stderr, "\nAborted.")
+			os.Exit(130)
+		}
 		customerrors.Format(os.Stderr, err, formatFor(rootCmd), verbosity())
 		os.Exit(activation.ExitCodeOf(err))
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestExitCodeForError_Interrupt verifies that a canceled context — how a
+// ^C/SIGTERM interrupt surfaces once the signal-derived context is wired into
+// the root command — maps to a quiet exit with code 130, including when the
+// cancellation is wrapped by intervening error handling.
+func TestExitCodeForError_Interrupt(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"direct", context.Canceled},
+		{"wrapped", fmt.Errorf("authentication failed: %w", context.Canceled)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, interrupted := exitCodeForError(tc.err)
+			if !interrupted {
+				t.Fatalf("expected interrupted=true for %v", tc.err)
+			}
+			if code != 130 {
+				t.Fatalf("expected exit code 130, got %d", code)
+			}
+		})
+	}
+}
+
+// TestExitCodeForError_NonInterrupt verifies a normal error is not treated as
+// an interrupt and yields a non-zero exit code.
+func TestExitCodeForError_NonInterrupt(t *testing.T) {
+	code, interrupted := exitCodeForError(errors.New("boom"))
+	if interrupted {
+		t.Fatal("expected interrupted=false for a non-cancellation error")
+	}
+	if code == 0 {
+		t.Fatal("expected a non-zero exit code for a failing command")
+	}
+}


### PR DESCRIPTION
## Problem

`datumctl login` hangs on `^C` while waiting for the auth callback (PKCE) or polling the device code. Only `SIGTERM`/closing the terminal quits it. Reported in #251.

## Root cause

The login flow blocks in a `select` with a `case <-ctx.Done()` branch for cancellation — but `ctx` was never cancellable:

- `main.go` runs `cli.RunNoErrOutput(rootCmd)`, which calls plain `cmd.Execute()`. No context is set, so Cobra defaults to `context.Background()`.
- Nothing wired `SIGINT` to a context anywhere in the repo.
- So `cmd.Context()` in `runLogin` is the background context; the `ctx.Done()` branches (`internal/authutil/login.go:223` PKCE, `:553` device poll) are dead code.
- A transitive dependency registers a `signal.Notify(os.Interrupt)` handler, which disables Go's default SIGINT termination process-wide — so `^C` does nothing.

## Fix

Wire `signal.NotifyContext(os.Interrupt, SIGTERM)` in `main` and set it on the root command via `SetContext` (Cobra honors `c.ctx` when set). The existing `ctx.Done()` branches then fire. On cancellation, exit quietly with code `130` instead of printing `error: context canceled`.

The exit-code decision is extracted into `exitCodeForError` so it is unit-testable. `login.go` is otherwise untouched — its cancellation branches already existed, just unreachable.

## Tests

- `exitCodeForError` maps a canceled context (direct **and** wrapped, e.g. `fmt.Errorf("...: %w", context.Canceled)`) to a quiet exit with code `130`, and leaves other errors as normal non-zero failures.
- `pollDeviceToken` returns `context.Canceled` promptly when its context is canceled mid-poll (~0.1s), guarding the cancellation contract the signal wiring depends on.

The `main`-level signal wiring itself is subprocess-level integration (it calls `os.Exit`), so it is covered manually below rather than by a unit test.

## Verification

```
datumctl login --no-browser   # reach "Waiting for authorization..."
kill -INT <pid>               # now exits immediately, prints "Aborted.", exit 130
```

Before: `^C` ignored, only `SIGTERM` killed it.

## Follow-up

`^D` (EOF graceful quit), also requested in #251, is #253 — stacked on this PR; it adds a stdin-EOF watcher since the wait does not read stdin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)