### PR TITLE
fix: quit login gracefully on ^D (EOF) during auth waits

### DIFF
--- a/internal/authutil/login.go
+++ b/internal/authutil/login.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -208,6 +209,11 @@ func runPKCEFlow(ctx context.Context, provider *oidc.Provider, clientID string, 
 
 	fmt.Println("\nWaiting for authentication callback...")
 
+	// Cancel the wait if the user sends EOF (^D) on stdin, in addition to
+	// the ^C/SIGTERM cancellation carried by ctx.
+	waitCtx, stopEOF := watchStdinEOF(ctx)
+	defer stopEOF()
+
 	var authCode string
 	select {
 	case code := <-codeChan:
@@ -220,9 +226,9 @@ func runPKCEFlow(ctx context.Context, provider *oidc.Provider, clientID string, 
 		}()
 	case err := <-errChan:
 		return nil, fmt.Errorf("authentication failed: %w", err)
-	case <-ctx.Done():
+	case <-waitCtx.Done():
 		go server.Shutdown(context.Background())
-		return nil, ctx.Err()
+		return nil, waitCtx.Err()
 	}
 
 	token, err := conf.Exchange(ctx, authCode,
@@ -469,7 +475,92 @@ func runDeviceFlow(ctx context.Context, providerURL string, clientID string, sco
 
 	fmt.Println("Waiting for authorization...")
 
-	return pollDeviceToken(ctx, tokenURL, clientID, deviceResp.DeviceCode, deviceResp.Interval, deviceResp.ExpiresIn)
+	// Cancel the poll if the user sends EOF (^D) on stdin, in addition to
+	// the ^C/SIGTERM cancellation carried by ctx.
+	waitCtx, stopEOF := watchStdinEOF(ctx)
+	defer stopEOF()
+
+	return pollDeviceToken(waitCtx, tokenURL, clientID, deviceResp.DeviceCode, deviceResp.Interval, deviceResp.ExpiresIn)
+}
+
+// deadlineReader is a stream that supports read deadlines, satisfied by
+// *os.File (including os.Stdin and os.Pipe ends).
+type deadlineReader interface {
+	io.Reader
+	SetReadDeadline(time.Time) error
+}
+
+// watchStdinEOF returns a context derived from parent that is canceled when
+// stdin reaches EOF (e.g. the user presses ^D at an empty line). See
+// watchReaderEOF for the behavior and the contract around the returned stop
+// function.
+func watchStdinEOF(parent context.Context) (context.Context, context.CancelFunc) {
+	return watchReaderEOF(parent, os.Stdin)
+}
+
+// watchReaderEOF returns a context derived from parent that is canceled when
+// in reaches EOF. The returned stop function must be called when the wait
+// completes so the background reader releases the stream and does not consume
+// input intended for a later interactive prompt.
+//
+// Input received during the wait is read and discarded — nothing else reads
+// the stream while login is blocking on the auth callback or device poll. On
+// streams where read deadlines are unsupported the watcher falls back to a
+// single blocking read; EOF still cancels, and any leftover reader is
+// abandoned rather than stealing later input in the common (deadline-capable)
+// case.
+func watchReaderEOF(parent context.Context, in deadlineReader) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+
+	go func() {
+		// Ensure the stream has no lingering read deadline once the watcher
+		// exits, so a later reader (e.g. the interactive picker) is not
+		// tripped by a stale deadline this goroutine may have re-armed after
+		// stop() cleared it.
+		defer in.SetReadDeadline(time.Time{}) //nolint:errcheck
+		buf := make([]byte, 1)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			if err := in.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+				// Deadlines unsupported for this stream; fall back to a
+				// single blocking read. EOF cancels; anything else ends the
+				// watcher to avoid a busy loop.
+				if _, rerr := in.Read(buf); errors.Is(rerr, io.EOF) {
+					cancel()
+				}
+				return
+			}
+
+			_, err := in.Read(buf)
+			switch {
+			case err == nil:
+				// Discard input received during the wait and keep watching.
+				continue
+			case errors.Is(err, os.ErrDeadlineExceeded):
+				continue
+			case errors.Is(err, io.EOF):
+				cancel()
+				return
+			default:
+				// Unexpected read error; stop watching.
+				return
+			}
+		}
+	}()
+
+	return ctx, func() {
+		close(done)
+		// Clear the deadline so a later reader (e.g. the interactive picker)
+		// is not affected by a stale one.
+		_ = in.SetReadDeadline(time.Time{})
+		cancel()
+	}
 }
 
 func requestDeviceAuthorization(ctx context.Context, endpoint string, clientID string, scopes []string) (*deviceAuthorizationResponse, error) {

--- a/internal/authutil/login_test.go
+++ b/internal/authutil/login_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,4 +53,83 @@ func TestPollDeviceToken_ContextCancel(t *testing.T) {
 	if atomic.LoadInt32(&calls) == 0 {
 		t.Fatal("expected at least one poll attempt before cancel")
 	}
+}
+
+// TestWatchReaderEOF_CancelsOnEOF verifies the ^D fix: reaching EOF on the
+// watched stream cancels the derived context, which aborts the login wait.
+func TestWatchReaderEOF_CancelsOnEOF(t *testing.T) {
+	r, w := mustPipe(t)
+	defer r.Close()
+
+	ctx, stop := watchReaderEOF(context.Background(), r)
+	defer stop()
+
+	// Closing the write end delivers EOF to the reader, as ^D does at a tty.
+	_ = w.Close()
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", ctx.Err())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("context was not canceled after EOF")
+	}
+}
+
+// TestWatchReaderEOF_DiscardsInputThenEOF verifies that input received during
+// the wait is consumed and discarded, and a subsequent EOF still cancels.
+func TestWatchReaderEOF_DiscardsInputThenEOF(t *testing.T) {
+	r, w := mustPipe(t)
+	defer r.Close()
+
+	ctx, stop := watchReaderEOF(context.Background(), r)
+	defer stop()
+
+	if _, err := w.Write([]byte("noise typed during the wait\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = w.Close()
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", ctx.Err())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("context was not canceled after input+EOF")
+	}
+}
+
+// TestWatchReaderEOF_NoCancelBeforeEOFOrStop verifies the watcher does not
+// cancel while the stream is open and idle (no ^D), so a successful login is
+// not spuriously aborted; stop() then releases it.
+func TestWatchReaderEOF_NoCancelBeforeEOFOrStop(t *testing.T) {
+	r, w := mustPipe(t)
+	defer r.Close()
+	defer w.Close()
+
+	ctx, stop := watchReaderEOF(context.Background(), r)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context canceled while stream open and idle")
+	case <-time.After(600 * time.Millisecond): // spans a couple read-deadline cycles
+	}
+
+	stop()
+	select {
+	case <-ctx.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("stop() did not cancel the context")
+	}
+}
+
+func mustPipe(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	return r, w
 }


### PR DESCRIPTION
## Problem

Second half of #251: `^D` (EOF) is ignored while `datumctl login` waits for the auth callback (PKCE) or polls the device code. Follows #252, which handled `^C`.

## Fix

Add `watchReaderEOF`, which derives a cancellable context from the wait's parent context and cancels it when the watched stream hits EOF. `watchStdinEOF` wraps `os.Stdin`; both interactive wait sites (`runPKCEFlow`, `runDeviceFlow`) use it.

- Input received during the wait is read and discarded — nothing else reads stdin while login blocks.
- The reader releases stdin and clears its read deadline once the wait completes (via both the `stop` func and a goroutine-exit `defer`), so it never steals input from the interactive context picker that runs after a successful login.
- On streams without read-deadline support, falls back to a single blocking read that still cancels on EOF.

Cancellation surfaces as `context.Canceled`, which `main` already reports as a quiet `Aborted.` with exit code `130` (added in #252).

## Tests

The watcher is factored into `watchReaderEOF(parent, deadlineReader)` so it can be exercised over an `os.Pipe`:

- **cancel-on-EOF** — closing the write end cancels the context with `context.Canceled`.
- **discard-input-then-EOF** — bytes written during the wait are consumed, and a subsequent EOF still cancels.
- **no-cancel-while-idle-until-stop** — an open, idle stream does not cancel (a successful login is not spuriously aborted); `stop()` then releases it.

## Verification

```
# EOF (stdin closed → immediate EOF, simulates ^D):
datumctl login --no-browser </dev/null   → "Aborted.", exit 130

# ^C still works (regression check):
datumctl login --no-browser; kill -INT <pid>   → "Aborted.", exit 130
```

`go test ./internal/authutil/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)